### PR TITLE
[#5] 의사 다건 조회 인덱싱 적용, 테스트 코드 리팩토링, 페이징 부분 누락 쿼리 추가

### DIFF
--- a/src/main/java/com/example/docconneting/common/enums/Major.java
+++ b/src/main/java/com/example/docconneting/common/enums/Major.java
@@ -5,7 +5,9 @@ import com.example.docconneting.common.exception.object.ClientException;
 
 public enum Major {
     INTERNAL_MEDICINE,
-    ORTHOPEDICS;
+    SURGERY,
+    PEDIATRICS,
+    DERMATOLOGY;
 
     public static Major of(String category) {
         for (Major major : values()) {

--- a/src/main/java/com/example/docconneting/domain/doctor/controller/DoctorController.java
+++ b/src/main/java/com/example/docconneting/domain/doctor/controller/DoctorController.java
@@ -4,7 +4,6 @@ import com.example.docconneting.common.response.PageResult;
 import com.example.docconneting.common.response.Response;
 import com.example.docconneting.domain.doctor.dto.DoctorResponse;
 import com.example.docconneting.domain.doctor.service.DoctorService;
-import com.example.docconneting.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -27,13 +26,13 @@ public class DoctorController {
 
     // 의사 다건 조회
     @GetMapping()
-    public ResponseEntity<Response<List<User>>> findDoctors(
+    public ResponseEntity<Response<List<DoctorResponse>>> findDoctors(
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size,
             @RequestParam(required = false) String category,
             @RequestParam(required = false) String name)
     {
-        PageResult<User> pageResult = doctorService.findDoctors(page, size, category, name);
+        PageResult<DoctorResponse> pageResult = doctorService.findDoctors(page, size, category, name);
         return ResponseEntity.ok().body(Response.of(pageResult.getContent(), pageResult.getPageInfo()));
     }
 }

--- a/src/main/java/com/example/docconneting/domain/doctor/dto/DoctorResponse.java
+++ b/src/main/java/com/example/docconneting/domain/doctor/dto/DoctorResponse.java
@@ -3,7 +3,6 @@ package com.example.docconneting.domain.doctor.dto;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 @Getter

--- a/src/main/java/com/example/docconneting/domain/doctor/dto/DoctorResponse.java
+++ b/src/main/java/com/example/docconneting/domain/doctor/dto/DoctorResponse.java
@@ -1,9 +1,12 @@
 package com.example.docconneting.domain.doctor.dto;
 
+import com.example.docconneting.domain.user.entity.User;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 public class DoctorResponse {
@@ -23,5 +26,19 @@ public class DoctorResponse {
         this.imageUrl = imageUrl;
         this.startTime = startTime;
         this.endTime = endTime;
+    }
+
+    public static List<DoctorResponse> toDoctorResponse(List<User> users) {
+        List<DoctorResponse> doctorResponseList = users.stream()
+                .map(user -> new DoctorResponse(
+                        user.getId(),
+                        user.getUsername(),
+                        user.getMajor().name(),
+                        user.getImage(),
+                        user.getStartTime(),
+                        user.getEndTime()
+                ))
+                .collect(Collectors.toList());
+        return doctorResponseList;
     }
 }

--- a/src/main/java/com/example/docconneting/domain/doctor/service/DoctorService.java
+++ b/src/main/java/com/example/docconneting/domain/doctor/service/DoctorService.java
@@ -38,10 +38,10 @@ public class DoctorService {
     }
 
     // 의사 다건 조회 검색
-    public PageResult<User> findDoctors(int page, int size, String category, String name) {
+    public PageResult<DoctorResponse> findDoctors(int page, int size, String category, String name) {
         Pageable pageable = PageRequest.of(page - 1, size);
         Page<User> result = userRepository.findDoctors(pageable, category, name);
-        List<User> users = result.getContent().stream().toList();
+        List<DoctorResponse> doctors = DoctorResponse.toDoctorResponse(result.getContent());
 
         PageInfo pageInfo = PageInfo.builder()
                 .pageNum(page)
@@ -50,6 +50,6 @@ public class DoctorService {
                 .totalPage(result.getTotalPages())
                 .build();
 
-        return new PageResult<>(users, pageInfo);
+        return new PageResult<>(doctors, pageInfo);
     }
 }

--- a/src/main/java/com/example/docconneting/domain/user/entity/User.java
+++ b/src/main/java/com/example/docconneting/domain/user/entity/User.java
@@ -10,11 +10,9 @@ import lombok.NoArgsConstructor;
 import java.time.LocalTime;
 
 @Entity
-@Table(
-        name = "users",
-        indexes = {
-//                @Index(name = "idx_user_category", columnList = "major"),
-        }
+@Table(name = "users",
+        indexes = { @Index(name = "idx1", columnList = "isDeleted"),
+                    @Index(name = "idx2", columnList = "major, isDeleted") }
 )
 @Getter
 @NoArgsConstructor

--- a/src/main/java/com/example/docconneting/domain/user/entity/User.java
+++ b/src/main/java/com/example/docconneting/domain/user/entity/User.java
@@ -7,7 +7,6 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 @Entity

--- a/src/main/java/com/example/docconneting/domain/user/entity/User.java
+++ b/src/main/java/com/example/docconneting/domain/user/entity/User.java
@@ -10,7 +10,12 @@ import lombok.NoArgsConstructor;
 import java.time.LocalTime;
 
 @Entity
-@Table(name = "users")
+@Table(
+        name = "users",
+        indexes = {
+//                @Index(name = "idx_user_category", columnList = "major"),
+        }
+)
 @Getter
 @NoArgsConstructor
 public class User extends BaseEntity {

--- a/src/main/java/com/example/docconneting/domain/user/repository/UserRepositoryQueryImpl.java
+++ b/src/main/java/com/example/docconneting/domain/user/repository/UserRepositoryQueryImpl.java
@@ -25,6 +25,8 @@ public class UserRepositoryQueryImpl implements UserRepositoryQuery{
                     .select(user)
                     .from(user)
                     .where(categoryEq(category), nameEq(name))
+                    .offset(pageable.getOffset())
+                    .limit(pageable.getPageSize())
                     .fetch();
 
         JPAQuery<Long> countQuery = jpaQueryFactory

--- a/src/main/java/com/example/docconneting/domain/user/repository/UserRepositoryQueryImpl.java
+++ b/src/main/java/com/example/docconneting/domain/user/repository/UserRepositoryQueryImpl.java
@@ -24,7 +24,7 @@ public class UserRepositoryQueryImpl implements UserRepositoryQuery{
         List<User> users = jpaQueryFactory
                     .select(user)
                     .from(user)
-                    .where(categoryEq(category), nameEq(name))
+                    .where(categoryEq(category), isDeletedEq(), nameEq(name))
                     .offset(pageable.getOffset())
                     .limit(pageable.getPageSize())
                     .fetch();
@@ -32,9 +32,13 @@ public class UserRepositoryQueryImpl implements UserRepositoryQuery{
         JPAQuery<Long> countQuery = jpaQueryFactory
                     .select(user.count())
                     .from(user)
-                    .where(categoryEq(category), nameEq(name));
+                    .where(categoryEq(category), isDeletedEq(), nameEq(name));
 
         return PageableExecutionUtils.getPage(users, pageable, countQuery::fetchOne);
+    }
+
+    BooleanExpression isDeletedEq() {
+        return user.isDeleted.eq(Boolean.FALSE);
     }
 
     BooleanExpression categoryEq(String category) {

--- a/src/test/java/com/example/docconneting/domain/doctor/controller/DoctorControllerTest.java
+++ b/src/test/java/com/example/docconneting/domain/doctor/controller/DoctorControllerTest.java
@@ -1,0 +1,118 @@
+package com.example.docconneting.domain.doctor.controller;
+
+import com.example.docconneting.common.enums.Major;
+import com.example.docconneting.common.response.PageInfo;
+import com.example.docconneting.common.response.PageResult;
+import com.example.docconneting.domain.doctor.dto.DoctorResponse;
+import com.example.docconneting.domain.doctor.service.DoctorService;
+import com.example.docconneting.domain.user.entity.User;
+import com.example.docconneting.domain.user.enums.UserRole;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(DoctorController.class)
+class DoctorControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @MockitoBean
+    private DoctorService doctorService;
+
+    @Test
+    public void 의사_단건_조회() throws Exception {
+        // given
+        long userId = 1L;
+        String username = "kimdoctor";
+        String major = "INTERNAL_MEDICINE";
+        String imageUrl = "https://example.com/image.jpg";
+        LocalTime startTime = LocalTime.of(9, 0);
+        LocalTime endTime = LocalTime.of(18, 0);
+
+        given(doctorService.findDoctor(userId)).willReturn(new DoctorResponse(userId, username, major, imageUrl, startTime, endTime));
+
+        // when & then
+        mockMvc.perform(get("/api/v1/doctors/{id}", userId))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.id").value(userId))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.name").value(username))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.imageUrl").value(imageUrl));
+    }
+
+    @Test
+    public void 의사_다건_조회() throws Exception {
+        // given
+        int page = 1;
+        int size = 5;
+        int totalElement = 2;
+        int totalPages = 1;
+
+        long userId1 = 1L;
+        String email1 = "test1@naver.com";
+        String password = "password";
+        String username1 = "kimdoctor";
+        String majorName = "INTERNAL_MEDICINE";
+        Major major = Major.of(majorName);
+        String image = "https://example.com/image.jpg";
+        LocalTime startTime = LocalTime.of(9, 0);
+        LocalTime endTime = LocalTime.of(18, 0);
+        boolean isDeleted = false;
+        UserRole userRole = UserRole.DOCTOR;
+        User user1 = new User(email1, password, username1, major, image, startTime, endTime, isDeleted, userRole);
+        ReflectionTestUtils.setField(user1, "id", userId1);
+
+        long userId2 = 2L;
+        String email2 = "test2@naver.com";
+        String username2 = "leedoctor";
+        User user2 = new User(email2, password, username2, major, image, startTime, endTime, isDeleted, userRole);
+        ReflectionTestUtils.setField(user2, "id", userId2);
+
+        List<User> users = new ArrayList<>();
+        users.add(user1);
+        users.add(user2);
+
+        PageInfo pageInfo = PageInfo.builder()
+                .pageNum(page)
+                .pageSize(size)
+                .totalElement(totalElement)
+                .totalPage(totalPages)
+                .build();
+
+        PageResult<User> pageResult = new PageResult<>(users, pageInfo);
+
+        given(doctorService.findDoctors(page, size, "", "")).willReturn(pageResult);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/doctors")
+                .param("page", String.valueOf(page))
+                .param("size", String.valueOf(size))
+                .param("category", "")
+                .param("name", ""))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].id").value(userId1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].username").value(username1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].id").value(userId2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].username").value(username2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.page.pageNum").value(page))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.page.pageSize").value(size))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalElement").value(totalElement))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalPage").value(totalPages));
+    }
+}

--- a/src/test/java/com/example/docconneting/domain/doctor/controller/DoctorControllerTest.java
+++ b/src/test/java/com/example/docconneting/domain/doctor/controller/DoctorControllerTest.java
@@ -7,6 +7,7 @@ import com.example.docconneting.domain.doctor.dto.DoctorResponse;
 import com.example.docconneting.domain.doctor.service.DoctorService;
 import com.example.docconneting.domain.user.entity.User;
 import com.example.docconneting.domain.user.enums.UserRole;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -36,6 +37,41 @@ class DoctorControllerTest {
     @MockitoBean
     private DoctorService doctorService;
 
+    private User user1;
+    private User user2;
+
+    @BeforeEach
+    void setUp() {
+        String majorName = "INTERNAL_MEDICINE";
+        Major major = Major.of(majorName);
+
+        user1 = new User(
+                "test1@naver.com",
+                "password",
+                "kimdoctor",
+                major,
+                "https://example.com/image.jpg",
+                LocalTime.of(9, 0),
+                LocalTime.of(18, 0),
+                false,
+                UserRole.DOCTOR
+        );
+        ReflectionTestUtils.setField(user1, "id", 1L);
+
+        user2 = new User(
+                "test2@naver.com",
+                "password",
+                "leedoctor",
+                major,
+                "https://example.com/image.jpg",
+                LocalTime.of(9, 0),
+                LocalTime.of(18, 0),
+                false,
+                UserRole.DOCTOR
+        );
+        ReflectionTestUtils.setField(user2, "id", 2L);
+    }
+
     @Test
     public void 의사_단건_조회() throws Exception {
         // given
@@ -64,29 +100,10 @@ class DoctorControllerTest {
         int totalElement = 2;
         int totalPages = 1;
 
-        long userId1 = 1L;
-        String email1 = "test1@naver.com";
-        String password = "password";
-        String username1 = "kimdoctor";
-        String majorName = "INTERNAL_MEDICINE";
-        Major major = Major.of(majorName);
-        String image = "https://example.com/image.jpg";
-        LocalTime startTime = LocalTime.of(9, 0);
-        LocalTime endTime = LocalTime.of(18, 0);
-        boolean isDeleted = false;
-        UserRole userRole = UserRole.DOCTOR;
-        User user1 = new User(email1, password, username1, major, image, startTime, endTime, isDeleted, userRole);
-        ReflectionTestUtils.setField(user1, "id", userId1);
-
-        long userId2 = 2L;
-        String email2 = "test2@naver.com";
-        String username2 = "leedoctor";
-        User user2 = new User(email2, password, username2, major, image, startTime, endTime, isDeleted, userRole);
-        ReflectionTestUtils.setField(user2, "id", userId2);
-
         List<User> users = new ArrayList<>();
         users.add(user1);
         users.add(user2);
+        List<DoctorResponse> doctors = DoctorResponse.toDoctorResponse(users);
 
         PageInfo pageInfo = PageInfo.builder()
                 .pageNum(page)
@@ -95,7 +112,7 @@ class DoctorControllerTest {
                 .totalPage(totalPages)
                 .build();
 
-        PageResult<User> pageResult = new PageResult<>(users, pageInfo);
+        PageResult<DoctorResponse> pageResult = new PageResult<>(doctors, pageInfo);
 
         given(doctorService.findDoctors(page, size, "", "")).willReturn(pageResult);
 
@@ -106,10 +123,10 @@ class DoctorControllerTest {
                 .param("category", "")
                 .param("name", ""))
                 .andExpect(status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].id").value(userId1))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].username").value(username1))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].id").value(userId2))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].username").value(username2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].id").value(user1.getId()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].name").value(user1.getUsername()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].id").value(user2.getId()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].name").value(user2.getUsername()))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.pageNum").value(page))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.pageSize").value(size))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalElement").value(totalElement))

--- a/src/test/java/com/example/docconneting/domain/doctor/service/DoctorServiceTest.java
+++ b/src/test/java/com/example/docconneting/domain/doctor/service/DoctorServiceTest.java
@@ -7,6 +7,7 @@ import com.example.docconneting.domain.doctor.dto.DoctorResponse;
 import com.example.docconneting.domain.user.entity.User;
 import com.example.docconneting.domain.user.enums.UserRole;
 import com.example.docconneting.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -19,6 +20,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -26,7 +28,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.mock;
 
 @ExtendWith(MockitoExtension.class)
 class DoctorServiceTest {
@@ -36,6 +37,45 @@ class DoctorServiceTest {
     
     @InjectMocks
     private DoctorService doctorService;
+
+    private String image;
+    private String majorName;
+
+    private User user1;
+    private User user2;
+
+    @BeforeEach
+    void setUp() {
+        image = "https://example.com/image.jpg";
+        majorName = "INTERNAL_MEDICINE";
+        Major major = Major.of(majorName);
+
+        user1 = new User(
+                "test1@naver.com",
+                "password",
+                "kimdoctor",
+                major,
+                image,
+                LocalTime.of(9, 0),
+                LocalTime.of(18, 0),
+                false,
+                UserRole.DOCTOR
+        );
+        ReflectionTestUtils.setField(user1, "id", 1L);
+
+        user2 = new User(
+                "test2@naver.com",
+                "password",
+                "leedoctor",
+                major,
+                image,
+                LocalTime.of(9, 0),
+                LocalTime.of(18, 0),
+                false,
+                UserRole.DOCTOR
+        );
+        ReflectionTestUtils.setField(user2, "id", 2L);
+    }
 
     @Test
     public void 존재하지_않는_Doctor_조회시_ClientException을_던진다() {
@@ -51,30 +91,16 @@ class DoctorServiceTest {
     @Test
     public void 의사를_ID로_조회할_수_있다() {
         // given
-        long userId = 1L;
-        String email = "test@naver.com";
-        String password = "password";
-        String username = "kimdoctor";
-        String majorName = "INTERNAL_MEDICINE";
-        Major major = Major.of(majorName);
-        String image = "https://example.com/image.jpg";
-        LocalTime startTime = LocalTime.of(9, 0);
-        LocalTime endTime = LocalTime.of(18, 0);
-        boolean isDeleted = false;
-        UserRole userRole = UserRole.DOCTOR;
-        User user = new User(email, password, username, major, image, startTime, endTime, isDeleted, userRole);
-        ReflectionTestUtils.setField(user, "id", userId);
-
-        given(userRepository.findByDoctorId(userId)).willReturn(Optional.of(user));
+        given(userRepository.findByDoctorId(1L)).willReturn(Optional.of(user1));
 
         // when
-        DoctorResponse response = doctorService.findDoctor(userId);
+        DoctorResponse response = doctorService.findDoctor(1L);
 
         // then
         assertThat(response).isNotNull();
-        assertThat(response.getId()).isEqualTo(userId);
-        assertThat(response.getName()).isEqualTo(username);
-        assertThat(response.getMajor()).isEqualTo(majorName);
+        assertThat(response.getId()).isEqualTo(1L);
+        assertThat(response.getName()).isEqualTo("kimdoctor");
+        assertThat(response.getImageUrl()).isEqualTo(image);
     }
 
     @Test
@@ -83,18 +109,21 @@ class DoctorServiceTest {
         int page = 1;
         int size = 5;
         String category = "INTERNAL_MEDICINE";
-        String name = "kimdoctor";
+        String name = "doctor";
 
-        List<User> users = List.of(mock(User.class), mock(User.class), mock(User.class), mock(User.class), mock(User.class));
-        Page<User> pageResult = new PageImpl<>(users, PageRequest.of(page - 1, 5), 5);
+        List<User> users = new ArrayList<>();
+        users.add(user1);
+        users.add(user2);
+
+        Page<User> pageResult = new PageImpl<>(users, PageRequest.of(page - 1, 5), 2);
         Mockito.when(userRepository.findDoctors(PageRequest.of(page - 1, size), category, name)).thenReturn(pageResult);
 
         // when
-        PageResult<User> result = doctorService.findDoctors(page, size, category, name);
+        PageResult<DoctorResponse> result = doctorService.findDoctors(page, size, category, name);
 
         // then
-        assertEquals(5, result.getContent().size());
-        assertEquals(5, result.getPageInfo().getTotalElement());
+        assertEquals(2, result.getContent().size());
+        assertEquals(2, result.getPageInfo().getTotalElement());
         assertEquals(page, result.getPageInfo().getPageNum());
         assertEquals(size, result.getPageInfo().getPageSize());
     }


### PR DESCRIPTION
#5 

- 의사 다건 조회시 카테고리와 삭제여부로 인덱싱 추가 (idx1 : 삭제여부, idx2 : 전공, 삭제여부) / 이름으로 검색하는 부분은 like이기 때문에 인덱스를 걸어도 걸리지 않아서 추후에 기능 개선 때 Elasticsearch 사용 예정
- 테스트 코드에서 데이터 세팅하는 부분 공통으로 분리
- 페이징 부분에서 누락되었던 쿼리 (limit, offset) 추가
- 다건 조회 부분에서 응답 DTO를 User에서 DoctorResponse로 변경