### PR TITLE
[#14] 회원가입, 로그인, 마이페이지 조회, 비밀번호 수정, 의사 이미지 수정, 토큰 재발급 기능 생성, pr 리뷰 기반 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,14 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    //login
+    implementation 'at.favre.lib:bcrypt:0.10.2'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ dependencies {
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
 
+    //redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/docconneting/common/config/FilterConfig.java
+++ b/src/main/java/com/example/docconneting/common/config/FilterConfig.java
@@ -1,0 +1,23 @@
+package com.example.docconneting.common.config;
+
+import com.example.docconneting.common.filter.JwtFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class FilterConfig {
+
+    private final JwtUtil jwtUtil;
+
+    @Bean
+    public FilterRegistrationBean<JwtFilter> jwtFilter() {
+        FilterRegistrationBean<JwtFilter> registrationBean = new FilterRegistrationBean<>();
+        registrationBean.setFilter(new JwtFilter(jwtUtil));
+        registrationBean.addUrlPatterns("/*");
+
+        return registrationBean;
+    }
+}

--- a/src/main/java/com/example/docconneting/common/config/JwtUtil.java
+++ b/src/main/java/com/example/docconneting/common/config/JwtUtil.java
@@ -1,0 +1,74 @@
+package com.example.docconneting.common.config;
+
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import org.springframework.stereotype.Component;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.util.StringUtils;
+
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+    private static final String BEARER_PREFIX = "Bearer ";
+    private static final long TOKEN_TIME = 60 * 60 * 1000L; // 60분
+    private static final long REFRESH_TOKEN_TIME = 14 * 24 * 60 * 60 * 1000L;
+
+    @Value("${jwt.secret.key}")
+    private String secretKey;
+    private Key key;
+    private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+
+    @PostConstruct
+    public void init() {
+        byte[] bytes = Base64.getDecoder().decode(secretKey);
+        key = Keys.hmacShaKeyFor(bytes);
+    }
+
+    //어세스 토큰 발급
+    public String createToken(Long userId) {
+        Date date = new Date();
+
+        return BEARER_PREFIX +
+                Jwts.builder()
+                        .setSubject(String.valueOf(userId))
+                        .setExpiration(new Date(date.getTime() + TOKEN_TIME))
+                        .setIssuedAt(date) // 발급일
+                        .signWith(key, signatureAlgorithm) // 암호화 알고리즘
+                        .compact();
+    }
+
+    //리프레시 토큰 발급
+    public String createRefreshToken(Long userId) {
+        Date date = new Date();
+
+        return BEARER_PREFIX +
+                Jwts.builder()
+                        .setSubject(String.valueOf(userId))
+                        .setExpiration(new Date(date.getTime() + REFRESH_TOKEN_TIME))
+                        .setIssuedAt(date)
+                        .signWith(key, signatureAlgorithm)
+                        .compact();
+    }
+
+    public String substringToken(String tokenValue) {
+        if (StringUtils.hasText(tokenValue) && tokenValue.startsWith(BEARER_PREFIX)) {
+            return tokenValue.substring(7);
+        }
+        throw new IllegalStateException("Not Found Token");
+    }
+
+    public Claims extractClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}

--- a/src/main/java/com/example/docconneting/common/config/JwtUtil.java
+++ b/src/main/java/com/example/docconneting/common/config/JwtUtil.java
@@ -1,6 +1,7 @@
 package com.example.docconneting.common.config;
 
 
+import com.example.docconneting.domain.user.enums.UserRole;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -32,12 +33,13 @@ public class JwtUtil {
     }
 
     //어세스 토큰 발급
-    public String createToken(Long userId) {
+    public String createToken(Long userId, UserRole userRole) {
         Date date = new Date();
 
         return BEARER_PREFIX +
                 Jwts.builder()
-                        .setSubject(String.valueOf(userId))
+                        .setSubject(String.valueOf(userId)) //id값 세팅
+                        .claim("role", userRole.name()) //role 값 세팅
                         .setExpiration(new Date(date.getTime() + TOKEN_TIME))
                         .setIssuedAt(date) // 발급일
                         .signWith(key, signatureAlgorithm) // 암호화 알고리즘

--- a/src/main/java/com/example/docconneting/common/config/JwtUtil.java
+++ b/src/main/java/com/example/docconneting/common/config/JwtUtil.java
@@ -1,6 +1,8 @@
 package com.example.docconneting.common.config;
 
 
+import com.example.docconneting.common.exception.constant.ErrorCode;
+import com.example.docconneting.common.exception.object.ClientException;
 import com.example.docconneting.domain.user.enums.UserRole;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
@@ -63,7 +65,7 @@ public class JwtUtil {
         if (StringUtils.hasText(tokenValue) && tokenValue.startsWith(BEARER_PREFIX)) {
             return tokenValue.substring(7);
         }
-        throw new IllegalStateException("Not Found Token");
+        throw new ClientException(ErrorCode.TOKEN_NOT_FOUND);
     }
 
     public Claims extractClaims(String token) {

--- a/src/main/java/com/example/docconneting/common/config/JwtUtil.java
+++ b/src/main/java/com/example/docconneting/common/config/JwtUtil.java
@@ -52,8 +52,7 @@ public class JwtUtil {
     public String createRefreshToken(Long userId) {
         Date date = new Date();
 
-        return BEARER_PREFIX +
-                Jwts.builder()
+        return Jwts.builder()
                         .setSubject(String.valueOf(userId))
                         .setExpiration(new Date(date.getTime() + REFRESH_TOKEN_TIME))
                         .setIssuedAt(date)

--- a/src/main/java/com/example/docconneting/common/config/PasswordEncoder.java
+++ b/src/main/java/com/example/docconneting/common/config/PasswordEncoder.java
@@ -1,0 +1,16 @@
+package com.example.docconneting.common.config;
+
+import at.favre.lib.crypto.bcrypt.BCrypt;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PasswordEncoder {
+    public String encode(String rawPassword) {
+        return BCrypt.withDefaults().hashToString(BCrypt.MIN_COST, rawPassword.toCharArray());
+    }
+
+    public boolean matches(String rawPassword, String encodedPassword) {
+        BCrypt.Result result = BCrypt.verifyer().verify(rawPassword.toCharArray(), encodedPassword);
+        return result.verified;
+    }
+}

--- a/src/main/java/com/example/docconneting/common/config/RedisConfig.java
+++ b/src/main/java/com/example/docconneting/common/config/RedisConfig.java
@@ -1,0 +1,23 @@
+package com.example.docconneting.common.config;
+
+import com.querydsl.core.annotations.Config;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Config
+public class RedisConfig {
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory(){
+        return new LettuceConnectionFactory();
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(){
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+        return template;
+    }
+}

--- a/src/main/java/com/example/docconneting/common/config/WebConfig.java
+++ b/src/main/java/com/example/docconneting/common/config/WebConfig.java
@@ -1,0 +1,15 @@
+package com.example.docconneting.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new AuthUserArgumentResolver());
+    }
+}

--- a/src/main/java/com/example/docconneting/common/config/WebConfig.java
+++ b/src/main/java/com/example/docconneting/common/config/WebConfig.java
@@ -1,5 +1,6 @@
 package com.example.docconneting.common.config;
 
+import com.example.docconneting.common.resolver.AuthUserArgumentResolver;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;

--- a/src/main/java/com/example/docconneting/common/exception/constant/ErrorCode.java
+++ b/src/main/java/com/example/docconneting/common/exception/constant/ErrorCode.java
@@ -9,19 +9,21 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     // 회원 에러코드
+    //401
     // 403
     EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."),
 
+
     //로그인 에러 코드
-    //400
-    USERROLE_NOT_FOUND(HttpStatus.BAD_REQUEST,"권한 이름을 잘못 입력하셨습니다."),
-    PASSWORD_NOT_EQUAL(HttpStatus.BAD_REQUEST,"비밀번호가 일치하지 않습니다."),
+    //401
+    USERROLE_NOT_FOUND(HttpStatus.BAD_REQUEST, "권한 이름을 잘못 입력하셨습니다."),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
 
     //404
-    IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND,"이미지는 필수 입력 값입니다."),
-    STARTTIME_NOT_FOUND(HttpStatus.NOT_FOUND,"근무 시작 시간은 필수 입력 값입니다."),
-    ENDTIME_NOT_FOUND(HttpStatus.NOT_FOUND,"근무 종료 시간은 필수 입력 값입니다."),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 회원입니다."),
+    IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "이미지는 필수 입력 값입니다."),
+    STARTTIME_NOT_FOUND(HttpStatus.NOT_FOUND, "근무 시작 시간은 필수 입력 값입니다."),
+    ENDTIME_NOT_FOUND(HttpStatus.NOT_FOUND, "근무 종료 시간은 필수 입력 값입니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
 
     // 의사 조회 에러코드
     //404

--- a/src/main/java/com/example/docconneting/common/exception/constant/ErrorCode.java
+++ b/src/main/java/com/example/docconneting/common/exception/constant/ErrorCode.java
@@ -12,6 +12,17 @@ public enum ErrorCode {
     // 403
     EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."),
 
+    //로그인 에러 코드
+    //400
+    USERROLE_NOT_FOUND(HttpStatus.BAD_REQUEST,"권한 이름을 잘못 입력하셨습니다."),
+    PASSWORD_NOT_EQUAL(HttpStatus.BAD_REQUEST,"비밀번호가 일치하지 않습니다."),
+
+    //404
+    IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND,"이미지는 필수 입력 값입니다."),
+    STARTTIME_NOT_FOUND(HttpStatus.NOT_FOUND,"근무 시작 시간은 필수 입력 값입니다."),
+    ENDTIME_NOT_FOUND(HttpStatus.NOT_FOUND,"근무 종료 시간은 필수 입력 값입니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 회원입니다."),
+
     // 의사 조회 에러코드
     //404
     DOCTOR_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 의사입니다."),

--- a/src/main/java/com/example/docconneting/common/exception/constant/ErrorCode.java
+++ b/src/main/java/com/example/docconneting/common/exception/constant/ErrorCode.java
@@ -9,15 +9,16 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     // 회원 에러코드
-    //401
     // 403
     EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."),
+    PASSWORD_SAME_AS_OLD(HttpStatus.BAD_REQUEST,"기존 비밀번호와 동일한 비밀번호로 수정할 수 없습니다."),
 
 
     //로그인 에러 코드
     //401
-    USERROLE_NOT_FOUND(HttpStatus.BAD_REQUEST, "권한 이름을 잘못 입력하셨습니다."),
-    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+    UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "의사만 접근 가능한 기능입니다."),
+    USERROLE_NOT_FOUND(HttpStatus.UNAUTHORIZED, "권한 이름을 잘못 입력하셨습니다."),
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
 
     //404
     IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "이미지는 필수 입력 값입니다."),

--- a/src/main/java/com/example/docconneting/common/exception/constant/ErrorCode.java
+++ b/src/main/java/com/example/docconneting/common/exception/constant/ErrorCode.java
@@ -8,26 +8,33 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ErrorCode {
 
-    // 회원 에러코드
-    // 403
+    //회원 에러코드
+    //400
     EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."),
     PASSWORD_SAME_AS_OLD(HttpStatus.BAD_REQUEST,"기존 비밀번호와 동일한 비밀번호로 수정할 수 없습니다."),
 
+    //404
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
+
+    //500
+    AUTH_WITHOUT_AUTHUSER(HttpStatus.INTERNAL_SERVER_ERROR,"@Auth와 AuthUser 타입은 함께 사용되어야 합니다."),
 
     //로그인 에러 코드
+    //400
+    USERROLE_NOT_FOUND(HttpStatus.BAD_REQUEST, "권한 이름을 잘못 입력하셨습니다."),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST,"리프레시 토큰이 일치하지 않습니다." ),
+    IMAGE_NOT_FOUND(HttpStatus.BAD_REQUEST, "이미지는 필수 입력 값입니다."),
+    STARTTIME_NOT_FOUND(HttpStatus.BAD_REQUEST, "근무 시작 시간은 필수 입력 값입니다."),
+    ENDTIME_NOT_FOUND(HttpStatus.BAD_REQUEST, "근무 종료 시간은 필수 입력 값입니다."),
+
     //401
     UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "의사만 접근 가능한 기능입니다."),
-    USERROLE_NOT_FOUND(HttpStatus.UNAUTHORIZED, "권한 이름을 잘못 입력하셨습니다."),
-    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
-    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED,"리프레시 토큰이 일치하지 않습니다." ),
+    EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED,"만료된 리프레시 토큰입니다."),
+
     //404
     TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND,"토큰이 존재하지 않습니다."),
 
-    //404
-    IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "이미지는 필수 입력 값입니다."),
-    STARTTIME_NOT_FOUND(HttpStatus.NOT_FOUND, "근무 시작 시간은 필수 입력 값입니다."),
-    ENDTIME_NOT_FOUND(HttpStatus.NOT_FOUND, "근무 종료 시간은 필수 입력 값입니다."),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
 
     // 의사 조회 에러코드
     //404

--- a/src/main/java/com/example/docconneting/common/exception/constant/ErrorCode.java
+++ b/src/main/java/com/example/docconneting/common/exception/constant/ErrorCode.java
@@ -19,6 +19,9 @@ public enum ErrorCode {
     UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "의사만 접근 가능한 기능입니다."),
     USERROLE_NOT_FOUND(HttpStatus.UNAUTHORIZED, "권한 이름을 잘못 입력하셨습니다."),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED,"리프레시 토큰이 일치하지 않습니다." ),
+    //404
+    TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND,"토큰이 존재하지 않습니다."),
 
     //404
     IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "이미지는 필수 입력 값입니다."),

--- a/src/main/java/com/example/docconneting/common/filter/JwtFilter.java
+++ b/src/main/java/com/example/docconneting/common/filter/JwtFilter.java
@@ -44,7 +44,7 @@ public class JwtFilter implements Filter {
         String bearerJwt = httpRequest.getHeader("Authorization");
 
         if (bearerJwt == null || !bearerJwt.startsWith("Bearer ")) {
-            httpResponse.sendError(HttpServletResponse.SC_BAD_REQUEST, "JWT 토큰이 필요합니다.");
+            httpResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, "JWT 토큰이 필요합니다.");
             return;
         }
 
@@ -58,6 +58,10 @@ public class JwtFilter implements Filter {
 
             Long userId = Long.parseLong(claims.getSubject());
             String role = claims.get("role", String.class);
+            if (role == null) {
+                httpResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, "JWT에 role 정보가 없습니다.");
+                return;
+            }
             UserRole userRole = UserRole.valueOf(role);
             httpRequest.setAttribute("userId", userId);
             httpRequest.setAttribute("userRole", userRole);
@@ -81,15 +85,17 @@ public class JwtFilter implements Filter {
 
     // URI + HTTP Method 기반 화이트리스트
     private boolean isWhiteList(String requestURI, String method) {
-        if (!"GET".equals(method)) {
-            return false;
+        if (requestURI.startsWith("/api/v1/signup") || requestURI.startsWith("/api/v1/signin")) {
+            return true;
         }
 
-        return requestURI.matches("^/api/v1/posts$") ||                          // /posts
-                requestURI.matches("^/api/v1/posts/\\d+$") ||                    // /posts/{id}
-                requestURI.matches("^/api/v1/posts/\\d+/comments$") ||           // /posts/{id}/comments
-                requestURI.startsWith("/api/v1/signup") ||
-                requestURI.startsWith("/api/v1/signin");
+        if ("GET".equals(method)) {
+            return requestURI.matches("^/api/v1/posts$") ||
+                    requestURI.matches("^/api/v1/posts/\\d+$") ||
+                    requestURI.matches("^/api/v1/posts/\\d+/comments$");
+        }
+
+        return false;
     }
 
     @Override

--- a/src/main/java/com/example/docconneting/common/filter/JwtFilter.java
+++ b/src/main/java/com/example/docconneting/common/filter/JwtFilter.java
@@ -1,6 +1,7 @@
 package com.example.docconneting.common.filter;
 
 import com.example.docconneting.common.config.JwtUtil;
+import com.example.docconneting.domain.user.enums.UserRole;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
@@ -55,7 +56,12 @@ public class JwtFilter implements Filter {
                 return;
             }
 
-            httpRequest.setAttribute("userId", Long.parseLong(claims.getSubject()));
+            Long userId = Long.parseLong(claims.getSubject());
+            String role = claims.get("role", String.class);
+            UserRole userRole = UserRole.valueOf(role);
+            httpRequest.setAttribute("userId", userId);
+            httpRequest.setAttribute("userRole", userRole);
+
             chain.doFilter(request, response);
 
         } catch (SecurityException | MalformedJwtException e) {

--- a/src/main/java/com/example/docconneting/common/filter/JwtFilter.java
+++ b/src/main/java/com/example/docconneting/common/filter/JwtFilter.java
@@ -85,7 +85,7 @@ public class JwtFilter implements Filter {
 
     // URI + HTTP Method 기반 화이트리스트
     private boolean isWhiteList(String requestURI, String method) {
-        if (requestURI.startsWith("/api/v1/signup") || requestURI.startsWith("/api/v1/signin")) {
+        if (requestURI.startsWith("/api/v1/signup") || requestURI.startsWith("/api/v1/signin") || requestURI.startsWith("/api/v1/refresh")) {
             return true;
         }
 
@@ -98,7 +98,6 @@ public class JwtFilter implements Filter {
         return false;
     }
 
-    @Override
     public void destroy() {
         Filter.super.destroy();
     }

--- a/src/main/java/com/example/docconneting/common/filter/JwtFilter.java
+++ b/src/main/java/com/example/docconneting/common/filter/JwtFilter.java
@@ -1,0 +1,93 @@
+package com.example.docconneting.common.filter;
+
+import com.example.docconneting.common.config.JwtUtil;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtFilter implements Filter {
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        Filter.super.init(filterConfig);
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        HttpServletResponse httpResponse = (HttpServletResponse) response;
+
+        String url = httpRequest.getRequestURI();
+        String method = httpRequest.getMethod();
+
+        // 화이트리스트 검사
+        if (isWhiteList(url, method)) {
+            chain.doFilter(httpRequest, httpResponse);
+            return;
+        }
+
+        String bearerJwt = httpRequest.getHeader("Authorization");
+
+        if (bearerJwt == null || !bearerJwt.startsWith("Bearer ")) {
+            httpResponse.sendError(HttpServletResponse.SC_BAD_REQUEST, "JWT 토큰이 필요합니다.");
+            return;
+        }
+
+        String jwt = jwtUtil.substringToken(bearerJwt);
+        try {
+            Claims claims = jwtUtil.extractClaims(jwt);
+            if (claims == null) {
+                httpResponse.sendError(HttpServletResponse.SC_BAD_REQUEST, "잘못된 JWT 토큰입니다.");
+                return;
+            }
+
+            httpRequest.setAttribute("userId", Long.parseLong(claims.getSubject()));
+            chain.doFilter(request, response);
+
+        } catch (SecurityException | MalformedJwtException e) {
+            log.error("유효하지 않은 JWT 서명입니다.", e);
+            httpResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, "유효하지 않은 JWT 서명입니다.");
+        } catch (ExpiredJwtException e) {
+            log.error("만료된 JWT 토큰입니다.", e);
+            httpResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, "만료된 JWT 토큰입니다.");
+        } catch (UnsupportedJwtException e) {
+            log.error("지원되지 않는 JWT 토큰입니다.", e);
+            httpResponse.sendError(HttpServletResponse.SC_BAD_REQUEST, "지원되지 않는 JWT 토큰입니다.");
+        } catch (Exception e) {
+            log.error("유효하지 않은 JWT 토큰입니다.", e);
+            httpResponse.sendError(HttpServletResponse.SC_BAD_REQUEST, "유효하지 않은 JWT 토큰입니다.");
+        }
+    }
+
+    // URI + HTTP Method 기반 화이트리스트
+    private boolean isWhiteList(String requestURI, String method) {
+        if (!"GET".equals(method)) {
+            return false;
+        }
+
+        return requestURI.matches("^/api/v1/posts$") ||                          // /posts
+                requestURI.matches("^/api/v1/posts/\\d+$") ||                    // /posts/{id}
+                requestURI.matches("^/api/v1/posts/\\d+/comments$") ||           // /posts/{id}/comments
+                requestURI.startsWith("/api/v1/signup") ||
+                requestURI.startsWith("/api/v1/signin");
+    }
+
+    @Override
+    public void destroy() {
+        Filter.super.destroy();
+    }
+}

--- a/src/main/java/com/example/docconneting/common/resolver/AuthUserArgumentResolver.java
+++ b/src/main/java/com/example/docconneting/common/resolver/AuthUserArgumentResolver.java
@@ -1,5 +1,7 @@
 package com.example.docconneting.common.resolver;
 
+import com.example.docconneting.common.exception.constant.ErrorCode;
+import com.example.docconneting.common.exception.object.ServerException;
 import com.example.docconneting.domain.Auth.annotation.Auth;
 import com.example.docconneting.domain.Auth.entity.AuthUser;
 import com.example.docconneting.domain.user.enums.UserRole;
@@ -21,7 +23,7 @@ public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
 
         // @Auth 어노테이션과 AuthUser 타입이 함께 사용되지 않은 경우 예외 발생
         if (hasAuthAnnotation != isAuthUserType) {
-            throw new IllegalStateException("@Auth와 AuthUser 타입은 함께 사용되어야 합니다.");
+            throw new ServerException(ErrorCode.AUTH_WITHOUT_AUTHUSER);
         }
 
         return hasAuthAnnotation;

--- a/src/main/java/com/example/docconneting/common/resolver/AuthUserArgumentResolver.java
+++ b/src/main/java/com/example/docconneting/common/resolver/AuthUserArgumentResolver.java
@@ -2,6 +2,7 @@ package com.example.docconneting.common.resolver;
 
 import com.example.docconneting.domain.Auth.annotation.Auth;
 import com.example.docconneting.domain.Auth.dto.AuthUser;
+import com.example.docconneting.domain.user.enums.UserRole;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.MethodParameter;
@@ -35,10 +36,9 @@ public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
     ) {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
 
-        // JwtFilter 에서 set 한 userId 값을 가져옴
+        // JwtFilter 에서 set 한 userId와 userRole 값을 가져옴
         Long userId = (Long) request.getAttribute("userId");
-        System.out.println("아이디 가져옴");
-        AuthUser authUser = new AuthUser(userId);
-        return authUser;
+        UserRole userRole = (UserRole) request.getAttribute("userRole");
+        return new AuthUser(userId,userRole);
     }
 }

--- a/src/main/java/com/example/docconneting/common/resolver/AuthUserArgumentResolver.java
+++ b/src/main/java/com/example/docconneting/common/resolver/AuthUserArgumentResolver.java
@@ -1,0 +1,44 @@
+package com.example.docconneting.common.resolver;
+
+import com.example.docconneting.domain.Auth.annotation.Auth;
+import com.example.docconneting.domain.Auth.dto.AuthUser;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.lang.Nullable;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Slf4j
+public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean hasAuthAnnotation = parameter.getParameterAnnotation(Auth.class) != null;
+        boolean isAuthUserType = parameter.getParameterType().equals(AuthUser.class);
+
+        // @Auth 어노테이션과 AuthUser 타입이 함께 사용되지 않은 경우 예외 발생
+        if (hasAuthAnnotation != isAuthUserType) {
+            throw new IllegalStateException("@Auth와 AuthUser 타입은 함께 사용되어야 합니다.");
+        }
+
+        return hasAuthAnnotation;
+    }
+
+    @Override
+    public Object resolveArgument(
+            @Nullable MethodParameter parameter,
+            @Nullable ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            @Nullable WebDataBinderFactory binderFactory
+    ) {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+
+        // JwtFilter 에서 set 한 userId 값을 가져옴
+        Long userId = (Long) request.getAttribute("userId");
+        System.out.println("아이디 가져옴");
+        AuthUser authUser = new AuthUser(userId);
+        return authUser;
+    }
+}

--- a/src/main/java/com/example/docconneting/common/resolver/AuthUserArgumentResolver.java
+++ b/src/main/java/com/example/docconneting/common/resolver/AuthUserArgumentResolver.java
@@ -1,7 +1,7 @@
 package com.example.docconneting.common.resolver;
 
 import com.example.docconneting.domain.Auth.annotation.Auth;
-import com.example.docconneting.domain.Auth.dto.AuthUser;
+import com.example.docconneting.domain.Auth.entity.AuthUser;
 import com.example.docconneting.domain.user.enums.UserRole;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
@@ -39,6 +39,6 @@ public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
         // JwtFilter 에서 set 한 userId와 userRole 값을 가져옴
         Long userId = (Long) request.getAttribute("userId");
         UserRole userRole = (UserRole) request.getAttribute("userRole");
-        return new AuthUser(userId,userRole);
+        return AuthUser.of(userId,userRole);
     }
 }

--- a/src/main/java/com/example/docconneting/domain/Auth/annotation/Auth.java
+++ b/src/main/java/com/example/docconneting/domain/Auth/annotation/Auth.java
@@ -1,0 +1,11 @@
+package com.example.docconneting.domain.Auth.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Auth {
+}

--- a/src/main/java/com/example/docconneting/domain/Auth/authservice/AuthService.java
+++ b/src/main/java/com/example/docconneting/domain/Auth/authservice/AuthService.java
@@ -15,9 +15,7 @@ import com.example.docconneting.domain.user.entity.User;
 import com.example.docconneting.domain.user.enums.UserRole;
 import com.example.docconneting.domain.user.repository.UserRepository;
 import org.springframework.transaction.annotation.Transactional;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.HashMap;
@@ -86,10 +84,10 @@ public class AuthService {
                 .orElseThrow(() -> new ClientException(ErrorCode.USER_NOT_FOUND));
 
         if (!passwordEncoder.matches(requestDto.getPassword(), user.getPassword())) {
-            throw new ClientException(ErrorCode.PASSWORD_NOT_EQUAL);
+            throw new ClientException(ErrorCode.INVALID_PASSWORD);
         }
 
-        String accessToken = jwtUtil.createToken(user.getId());
+        String accessToken = jwtUtil.createToken(user.getId(), user.getUserRole());
         String refreshToken = jwtUtil.createRefreshToken(user.getId());
 
         return UserSignInResponseDto.builder()

--- a/src/main/java/com/example/docconneting/domain/Auth/authservice/AuthService.java
+++ b/src/main/java/com/example/docconneting/domain/Auth/authservice/AuthService.java
@@ -1,0 +1,106 @@
+package com.example.docconneting.domain.Auth.authservice;
+
+import com.example.docconneting.common.config.JwtUtil;
+import com.example.docconneting.common.config.PasswordEncoder;
+import com.example.docconneting.common.enums.Major;
+import com.example.docconneting.common.exception.constant.ErrorCode;
+import com.example.docconneting.common.exception.object.ClientException;
+import com.example.docconneting.common.response.Response;
+import com.example.docconneting.domain.Auth.dto.request.UserRefreshTokenRequestDto;
+import com.example.docconneting.domain.Auth.dto.request.UserSignUpRequestDto;
+import com.example.docconneting.domain.Auth.dto.request.UserSigninRequestDto;
+import com.example.docconneting.domain.Auth.dto.response.UserRefreshTokenResponseDto;
+import com.example.docconneting.domain.Auth.dto.response.UserSignInResponseDto;
+import com.example.docconneting.domain.user.entity.User;
+import com.example.docconneting.domain.user.enums.UserRole;
+import com.example.docconneting.domain.user.repository.UserRepository;
+import org.springframework.transaction.annotation.Transactional;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtUtil jwtUtil;
+
+    // 회원가입
+    @Transactional
+    public Response<Map<String, String>> signUp(UserSignUpRequestDto dto) {
+        String password = passwordEncoder.encode(dto.getPassword());
+        UserRole role = UserRole.of(dto.getUserRole().toUpperCase());
+
+        User user;
+
+        if (role == UserRole.DOCTOR) {
+            if (dto.getMajor() == null) {
+                throw new ClientException(ErrorCode.MAJOR_NOT_FOUND);
+            }
+            if (dto.getImage() == null) {
+                throw new ClientException(ErrorCode.IMAGE_NOT_FOUND);
+            }
+            if (dto.getStartTime() == null) {
+                throw new ClientException(ErrorCode.STARTTIME_NOT_FOUND);
+            }
+            if (dto.getEndTime() == null) {
+                throw new ClientException(ErrorCode.ENDTIME_NOT_FOUND);
+            }
+
+            user = new User(
+                    dto.getEmail(),
+                    password,
+                    dto.getUsername(),
+                    Major.of(dto.getMajor().toUpperCase()),
+                    dto.getImage(),
+                    dto.getStartTime(),
+                    dto.getEndTime(),
+                    false,
+                    role
+            );
+
+        } else if (role == UserRole.ADMIN) {
+            user = new User(dto.getEmail(), password, dto.getUsername(), 0, false, role);
+
+        } else {
+            user = new User(dto.getEmail(), password, dto.getUsername(), 0, false, UserRole.PATIENT);
+        }
+
+        userRepository.save(user);
+
+        Map<String, String> message = new HashMap<>();
+        message.put("message", "회원 가입이 성공적으로 됐습니다");
+        return Response.of(message);
+    }
+
+    // 로그인
+    @Transactional(readOnly = true)
+    public UserSignInResponseDto signIn(UserSigninRequestDto requestDto) {
+        User user = userRepository.findByEmail(requestDto.getEmail())
+                .orElseThrow(() -> new ClientException(ErrorCode.USER_NOT_FOUND));
+
+        if (!passwordEncoder.matches(requestDto.getPassword(), user.getPassword())) {
+            throw new ClientException(ErrorCode.PASSWORD_NOT_EQUAL);
+        }
+
+        String accessToken = jwtUtil.createToken(user.getId());
+        String refreshToken = jwtUtil.createRefreshToken(user.getId());
+
+        return UserSignInResponseDto.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    //토큰 재발급
+    @Transactional
+    public UserRefreshTokenResponseDto refreshToken(UserRefreshTokenRequestDto requestDto) {
+        return null;
+    }
+}

--- a/src/main/java/com/example/docconneting/domain/Auth/controller/AuthController.java
+++ b/src/main/java/com/example/docconneting/domain/Auth/controller/AuthController.java
@@ -1,0 +1,57 @@
+package com.example.docconneting.domain.Auth.controller;
+
+import com.example.docconneting.common.response.Response;
+import com.example.docconneting.domain.Auth.authservice.AuthService;
+import com.example.docconneting.domain.Auth.dto.request.UserRefreshTokenRequestDto;
+import com.example.docconneting.domain.Auth.dto.request.UserSignUpRequestDto;
+import com.example.docconneting.domain.Auth.dto.request.UserSigninRequestDto;
+import com.example.docconneting.domain.Auth.dto.response.UserRefreshTokenResponseDto;
+import com.example.docconneting.domain.Auth.dto.response.UserSignInResponseDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.Map;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class AuthController {
+
+    private final AuthService authService;
+
+    //회원가입
+    @PostMapping("/signup")
+    public ResponseEntity<Response<Map<String, String>>> signUp(
+            @Valid @RequestBody UserSignUpRequestDto requestDto
+    ){
+        Response<Map<String, String>> response = authService.signUp(requestDto);
+
+        return ResponseEntity.ok(response);
+    }
+
+    //로그인
+    @PostMapping("/signin")
+    public ResponseEntity<Response<UserSignInResponseDto>> signIn(
+            @Valid @RequestBody UserSigninRequestDto requestDto
+    ){
+        UserSignInResponseDto response = authService.signIn(requestDto);
+
+        return ResponseEntity.ok(Response.of(response));
+    }
+
+    //토큰 재발급
+    @PostMapping
+    public ResponseEntity<Response<UserRefreshTokenResponseDto>> refreshToken(
+            @Valid @RequestBody UserRefreshTokenRequestDto requestDto
+            ){
+        UserRefreshTokenResponseDto response = authService.refreshToken(requestDto);
+
+        return ResponseEntity.ok(Response.of(response));
+    }
+}

--- a/src/main/java/com/example/docconneting/domain/Auth/controller/AuthController.java
+++ b/src/main/java/com/example/docconneting/domain/Auth/controller/AuthController.java
@@ -2,7 +2,7 @@ package com.example.docconneting.domain.Auth.controller;
 
 import com.example.docconneting.common.response.Response;
 import com.example.docconneting.domain.Auth.annotation.Auth;
-import com.example.docconneting.domain.Auth.dto.AuthUser;
+import com.example.docconneting.domain.Auth.entity.AuthUser;
 import com.example.docconneting.domain.Auth.service.AuthService;
 import com.example.docconneting.domain.Auth.dto.request.UserRefreshTokenRequestDto;
 import com.example.docconneting.domain.Auth.dto.request.UserSignUpRequestDto;

--- a/src/main/java/com/example/docconneting/domain/Auth/controller/AuthController.java
+++ b/src/main/java/com/example/docconneting/domain/Auth/controller/AuthController.java
@@ -1,7 +1,9 @@
 package com.example.docconneting.domain.Auth.controller;
 
 import com.example.docconneting.common.response.Response;
-import com.example.docconneting.domain.Auth.authservice.AuthService;
+import com.example.docconneting.domain.Auth.annotation.Auth;
+import com.example.docconneting.domain.Auth.dto.AuthUser;
+import com.example.docconneting.domain.Auth.service.AuthService;
 import com.example.docconneting.domain.Auth.dto.request.UserRefreshTokenRequestDto;
 import com.example.docconneting.domain.Auth.dto.request.UserSignUpRequestDto;
 import com.example.docconneting.domain.Auth.dto.request.UserSigninRequestDto;
@@ -9,7 +11,6 @@ import com.example.docconneting.domain.Auth.dto.response.UserRefreshTokenRespons
 import com.example.docconneting.domain.Auth.dto.response.UserSignInResponseDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -29,7 +30,7 @@ public class AuthController {
     @PostMapping("/signup")
     public ResponseEntity<Response<Map<String, String>>> signUp(
             @Valid @RequestBody UserSignUpRequestDto requestDto
-    ){
+    ) {
         Response<Map<String, String>> response = authService.signUp(requestDto);
 
         return ResponseEntity.ok(response);
@@ -39,18 +40,19 @@ public class AuthController {
     @PostMapping("/signin")
     public ResponseEntity<Response<UserSignInResponseDto>> signIn(
             @Valid @RequestBody UserSigninRequestDto requestDto
-    ){
+    ) {
         UserSignInResponseDto response = authService.signIn(requestDto);
 
         return ResponseEntity.ok(Response.of(response));
     }
 
     //토큰 재발급
-    @PostMapping
+    @PostMapping("/refresh")
     public ResponseEntity<Response<UserRefreshTokenResponseDto>> refreshToken(
+            @Auth AuthUser authUser,
             @Valid @RequestBody UserRefreshTokenRequestDto requestDto
-            ){
-        UserRefreshTokenResponseDto response = authService.refreshToken(requestDto);
+    ) {
+        UserRefreshTokenResponseDto response = authService.refreshToken(authUser, requestDto);
 
         return ResponseEntity.ok(Response.of(response));
     }

--- a/src/main/java/com/example/docconneting/domain/Auth/controller/AuthController.java
+++ b/src/main/java/com/example/docconneting/domain/Auth/controller/AuthController.java
@@ -31,9 +31,9 @@ public class AuthController {
     public ResponseEntity<Response<Map<String, String>>> signUp(
             @Valid @RequestBody UserSignUpRequestDto requestDto
     ) {
-        Response<Map<String, String>> response = authService.signUp(requestDto);
+        Map<String, String> response = authService.signUp(requestDto);
 
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(Response.of(response));
     }
 
     //로그인
@@ -52,7 +52,7 @@ public class AuthController {
             @Auth AuthUser authUser,
             @Valid @RequestBody UserRefreshTokenRequestDto requestDto
     ) {
-        UserRefreshTokenResponseDto response = authService.refreshToken(authUser, requestDto);
+        UserRefreshTokenResponseDto response = authService.refreshAccessToken(authUser, requestDto);
 
         return ResponseEntity.ok(Response.of(response));
     }

--- a/src/main/java/com/example/docconneting/domain/Auth/dto/AuthUser.java
+++ b/src/main/java/com/example/docconneting/domain/Auth/dto/AuthUser.java
@@ -1,12 +1,15 @@
 package com.example.docconneting.domain.Auth.dto;
 
+import com.example.docconneting.domain.user.enums.UserRole;
 import lombok.Getter;
 
 @Getter
 public class AuthUser {
     private final Long id;
+    private final UserRole userRole;
 
-    public AuthUser(Long id) {
+    public AuthUser(Long id, UserRole userRole) {
         this.id = id;
+        this.userRole = userRole;
     }
 }

--- a/src/main/java/com/example/docconneting/domain/Auth/dto/AuthUser.java
+++ b/src/main/java/com/example/docconneting/domain/Auth/dto/AuthUser.java
@@ -1,0 +1,12 @@
+package com.example.docconneting.domain.Auth.dto;
+
+import lombok.Getter;
+
+@Getter
+public class AuthUser {
+    private final Long id;
+
+    public AuthUser(Long id) {
+        this.id = id;
+    }
+}

--- a/src/main/java/com/example/docconneting/domain/Auth/dto/request/UserRefreshTokenRequestDto.java
+++ b/src/main/java/com/example/docconneting/domain/Auth/dto/request/UserRefreshTokenRequestDto.java
@@ -1,0 +1,10 @@
+package com.example.docconneting.domain.Auth.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class UserRefreshTokenRequestDto {
+    @NotNull(message = "토큰은 필수 입력값 입니다.")
+    private String refreshToken;
+}

--- a/src/main/java/com/example/docconneting/domain/Auth/dto/request/UserRefreshTokenRequestDto.java
+++ b/src/main/java/com/example/docconneting/domain/Auth/dto/request/UserRefreshTokenRequestDto.java
@@ -1,10 +1,10 @@
 package com.example.docconneting.domain.Auth.dto.request;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
 public class UserRefreshTokenRequestDto {
-    @NotNull(message = "토큰은 필수 입력값 입니다.")
+    @NotBlank(message = "토큰은 필수 입력값 입니다.")
     private String refreshToken;
 }

--- a/src/main/java/com/example/docconneting/domain/Auth/dto/request/UserSignUpRequestDto.java
+++ b/src/main/java/com/example/docconneting/domain/Auth/dto/request/UserSignUpRequestDto.java
@@ -1,0 +1,35 @@
+package com.example.docconneting.domain.Auth.dto.request;
+
+import com.example.docconneting.common.enums.Major;
+import com.example.docconneting.domain.user.enums.UserRole;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.time.LocalTime;
+
+@Getter
+public class UserSignUpRequestDto {
+    @Email
+    @NotBlank(message = "이메일은 필수 입력 값입니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+    private String password;
+
+    @NotBlank(message = "이름은 필수 입력 값입니다.")
+    private String username;
+
+    @NotNull(message = "역할은 필수 입력 값입니다.")
+    private String userRole; // DOCTOR or PATIENT or ADMIN
+
+    // 의사 전용 필드
+    private String major;
+
+    private String image;
+
+    private LocalTime startTime;
+
+    private LocalTime endTime;
+}

--- a/src/main/java/com/example/docconneting/domain/Auth/dto/request/UserSignUpRequestDto.java
+++ b/src/main/java/com/example/docconneting/domain/Auth/dto/request/UserSignUpRequestDto.java
@@ -1,10 +1,7 @@
 package com.example.docconneting.domain.Auth.dto.request;
 
-import com.example.docconneting.common.enums.Major;
-import com.example.docconneting.domain.user.enums.UserRole;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 import java.time.LocalTime;
@@ -21,7 +18,7 @@ public class UserSignUpRequestDto {
     @NotBlank(message = "이름은 필수 입력 값입니다.")
     private String username;
 
-    @NotNull(message = "역할은 필수 입력 값입니다.")
+    @NotBlank(message = "역할은 필수 입력 값입니다.")
     private String userRole; // DOCTOR or PATIENT or ADMIN
 
     // 의사 전용 필드

--- a/src/main/java/com/example/docconneting/domain/Auth/dto/request/UserSigninRequestDto.java
+++ b/src/main/java/com/example/docconneting/domain/Auth/dto/request/UserSigninRequestDto.java
@@ -1,13 +1,13 @@
 package com.example.docconneting.domain.Auth.dto.request;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
 public class UserSigninRequestDto {
-    @NotNull(message = "이메일은 필수 입력값입니다.")
+    @NotBlank(message = "이메일은 필수 입력값입니다.")
     private String email;
 
-    @NotNull(message = "비밀번호는 필수 입력값입니다.")
+    @NotBlank(message = "비밀번호는 필수 입력값입니다.")
     private String password;
 }

--- a/src/main/java/com/example/docconneting/domain/Auth/dto/request/UserSigninRequestDto.java
+++ b/src/main/java/com/example/docconneting/domain/Auth/dto/request/UserSigninRequestDto.java
@@ -1,0 +1,13 @@
+package com.example.docconneting.domain.Auth.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class UserSigninRequestDto {
+    @NotNull(message = "이메일은 필수 입력값입니다.")
+    private String email;
+
+    @NotNull(message = "비밀번호는 필수 입력값입니다.")
+    private String password;
+}

--- a/src/main/java/com/example/docconneting/domain/Auth/dto/response/UserRefreshTokenResponseDto.java
+++ b/src/main/java/com/example/docconneting/domain/Auth/dto/response/UserRefreshTokenResponseDto.java
@@ -1,7 +1,6 @@
 package com.example.docconneting.domain.Auth.dto.response;
 
 
-import lombok.Builder;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/example/docconneting/domain/Auth/dto/response/UserRefreshTokenResponseDto.java
+++ b/src/main/java/com/example/docconneting/domain/Auth/dto/response/UserRefreshTokenResponseDto.java
@@ -9,9 +9,12 @@ public class UserRefreshTokenResponseDto {
     private String accessToken;
     private String refreshToken;
 
-    @Builder
-    public UserRefreshTokenResponseDto(String accessToken, String refreshToken){
+    private UserRefreshTokenResponseDto(String accessToken, String refreshToken){
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;
+    }
+
+    public static UserRefreshTokenResponseDto of(String accessToken, String refreshToken){
+        return new UserRefreshTokenResponseDto(accessToken,refreshToken);
     }
 }

--- a/src/main/java/com/example/docconneting/domain/Auth/dto/response/UserRefreshTokenResponseDto.java
+++ b/src/main/java/com/example/docconneting/domain/Auth/dto/response/UserRefreshTokenResponseDto.java
@@ -1,0 +1,17 @@
+package com.example.docconneting.domain.Auth.dto.response;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class UserRefreshTokenResponseDto {
+    private String accessToken;
+    private String refreshToken;
+
+    @Builder
+    public UserRefreshTokenResponseDto(String accessToken, String refreshToken){
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/example/docconneting/domain/Auth/dto/response/UserSignInResponseDto.java
+++ b/src/main/java/com/example/docconneting/domain/Auth/dto/response/UserSignInResponseDto.java
@@ -1,6 +1,5 @@
 package com.example.docconneting.domain.Auth.dto.response;
 
-import lombok.Builder;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/example/docconneting/domain/Auth/dto/response/UserSignInResponseDto.java
+++ b/src/main/java/com/example/docconneting/domain/Auth/dto/response/UserSignInResponseDto.java
@@ -1,0 +1,16 @@
+package com.example.docconneting.domain.Auth.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class UserSignInResponseDto {
+    private String accessToken;
+    private String refreshToken;
+
+    @Builder
+    public UserSignInResponseDto(String accessToken, String refreshToken){
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/example/docconneting/domain/Auth/dto/response/UserSignInResponseDto.java
+++ b/src/main/java/com/example/docconneting/domain/Auth/dto/response/UserSignInResponseDto.java
@@ -8,9 +8,12 @@ public class UserSignInResponseDto {
     private String accessToken;
     private String refreshToken;
 
-    @Builder
-    public UserSignInResponseDto(String accessToken, String refreshToken){
+    private UserSignInResponseDto(String accessToken, String refreshToken){
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;
+    }
+
+    public static UserSignInResponseDto of(String accessToken, String refreshToken){
+        return new UserSignInResponseDto(accessToken, refreshToken);
     }
 }

--- a/src/main/java/com/example/docconneting/domain/Auth/entity/AuthUser.java
+++ b/src/main/java/com/example/docconneting/domain/Auth/entity/AuthUser.java
@@ -1,4 +1,4 @@
-package com.example.docconneting.domain.Auth.dto;
+package com.example.docconneting.domain.Auth.entity;
 
 import com.example.docconneting.domain.user.enums.UserRole;
 import lombok.Getter;
@@ -8,8 +8,13 @@ public class AuthUser {
     private final Long id;
     private final UserRole userRole;
 
-    public AuthUser(Long id, UserRole userRole) {
+    private AuthUser(Long id, UserRole userRole) {
         this.id = id;
         this.userRole = userRole;
+    }
+
+    public static AuthUser of(Long id, UserRole userRole)
+    {
+        return new AuthUser(id, userRole);
     }
 }

--- a/src/main/java/com/example/docconneting/domain/Auth/service/AuthService.java
+++ b/src/main/java/com/example/docconneting/domain/Auth/service/AuthService.java
@@ -34,7 +34,7 @@ public class AuthService {
 
     // 회원가입
     @Transactional
-    public Response<Map<String, String>> signUp(UserSignUpRequestDto dto) {
+    public Map<String, String> signUp(UserSignUpRequestDto dto) {
         String password = passwordEncoder.encode(dto.getPassword());
         UserRole role = UserRole.of(dto.getUserRole().toUpperCase());
 
@@ -90,7 +90,7 @@ public class AuthService {
 
         Map<String, String> message = new HashMap<>();
         message.put("message", "회원 가입이 성공적으로 됐습니다");
-        return Response.of(message);
+        return message;
     }
 
     // 로그인
@@ -105,6 +105,7 @@ public class AuthService {
 
         String accessToken = jwtUtil.createToken(user.getId(), user.getUserRole());
         String refreshToken = jwtUtil.createRefreshToken(user.getId());
+
         // refreshToken을 Redis에 저장
         refreshTokenService.saveRefreshToken(user.getId(), refreshToken);
 
@@ -113,19 +114,33 @@ public class AuthService {
 
     //토큰 재발급
     @Transactional
-    public UserRefreshTokenResponseDto refreshToken(AuthUser authuser, UserRefreshTokenRequestDto dto) {
+    public UserRefreshTokenResponseDto refreshAccessToken(AuthUser authuser, UserRefreshTokenRequestDto dto) {
         User user = userRepository.findById(authuser.getId())
                 .orElseThrow(() -> new ClientException(ErrorCode.USER_NOT_FOUND));
-        String refreshToken = jwtUtil.substringToken(dto.getRefreshToken());
-        Claims claims = jwtUtil.extractClaims(refreshToken);
 
-        String savedToken = refreshTokenService.getRefreshToken(user.getId());
-        if (!refreshToken.equals(savedToken)) {
+        // Redis에서 저장된 토큰 조회
+        String savedToken = refreshTokenService.getRefreshToken(authuser.getId());
+
+        //리프레시 토큰 만료 확인
+        Long ttl = refreshTokenService.getRefreshTokenTTL(authuser.getId());
+        if (ttl == null || ttl <= 0) {
+            throw new ClientException(ErrorCode.EXPIRED_REFRESH_TOKEN);
+        }
+
+        //dto와 DB에 있는 리프레시 토큰 비교
+        if (savedToken == null ||!dto.getRefreshToken().equals(savedToken)) {
             throw new ClientException(ErrorCode.INVALID_REFRESH_TOKEN);
         }
 
+        //어세스 토큰 재발급
         String newAccessToken = jwtUtil.createToken(user.getId(), user.getUserRole());
 
-        return UserRefreshTokenResponseDto.of(newAccessToken, refreshToken);
+        //리프레시 토큰 재발급
+        String newRefreshToken = jwtUtil.createRefreshToken(user.getId());
+
+        //리프레시 토큰 레디스에 업데이트
+        refreshTokenService.saveRefreshToken(user.getId(), newRefreshToken);
+
+        return UserRefreshTokenResponseDto.of(newAccessToken, newRefreshToken);
     }
 }

--- a/src/main/java/com/example/docconneting/domain/Auth/service/AuthService.java
+++ b/src/main/java/com/example/docconneting/domain/Auth/service/AuthService.java
@@ -6,7 +6,7 @@ import com.example.docconneting.common.enums.Major;
 import com.example.docconneting.common.exception.constant.ErrorCode;
 import com.example.docconneting.common.exception.object.ClientException;
 import com.example.docconneting.common.response.Response;
-import com.example.docconneting.domain.Auth.dto.AuthUser;
+import com.example.docconneting.domain.Auth.entity.AuthUser;
 import com.example.docconneting.domain.Auth.dto.request.UserRefreshTokenRequestDto;
 import com.example.docconneting.domain.Auth.dto.request.UserSignUpRequestDto;
 import com.example.docconneting.domain.Auth.dto.request.UserSigninRequestDto;
@@ -38,40 +38,53 @@ public class AuthService {
         String password = passwordEncoder.encode(dto.getPassword());
         UserRole role = UserRole.of(dto.getUserRole().toUpperCase());
 
-        User user;
+        User user = switch (role) {
+            case DOCTOR -> {
+                if (dto.getMajor() == null) {
+                    throw new ClientException(ErrorCode.MAJOR_NOT_FOUND);
+                }
+                if (dto.getImage() == null) {
+                    throw new ClientException(ErrorCode.IMAGE_NOT_FOUND);
+                }
+                if (dto.getStartTime() == null) {
+                    throw new ClientException(ErrorCode.STARTTIME_NOT_FOUND);
+                }
+                if (dto.getEndTime() == null) {
+                    throw new ClientException(ErrorCode.ENDTIME_NOT_FOUND);
+                }
 
-        if (role == UserRole.DOCTOR) {
-            if (dto.getMajor() == null) {
-                throw new ClientException(ErrorCode.MAJOR_NOT_FOUND);
-            }
-            if (dto.getImage() == null) {
-                throw new ClientException(ErrorCode.IMAGE_NOT_FOUND);
-            }
-            if (dto.getStartTime() == null) {
-                throw new ClientException(ErrorCode.STARTTIME_NOT_FOUND);
-            }
-            if (dto.getEndTime() == null) {
-                throw new ClientException(ErrorCode.ENDTIME_NOT_FOUND);
+                Major major = Major.of(dto.getMajor().toUpperCase());
+                yield User.of(
+                        dto.getEmail(),
+                        password,
+                        dto.getUsername(),
+                        major,
+                        dto.getImage(),
+                        dto.getStartTime(),
+                        dto.getEndTime(),
+                        false,
+                        role
+                );
             }
 
-            user = new User(
+            case ADMIN -> User.of(
                     dto.getEmail(),
                     password,
                     dto.getUsername(),
-                    Major.of(dto.getMajor().toUpperCase()),
-                    dto.getImage(),
-                    dto.getStartTime(),
-                    dto.getEndTime(),
+                    0,
                     false,
                     role
             );
 
-        } else if (role == UserRole.ADMIN) {
-            user = new User(dto.getEmail(), password, dto.getUsername(), 0, false, role);
-
-        } else {
-            user = new User(dto.getEmail(), password, dto.getUsername(), 0, false, UserRole.PATIENT);
-        }
+            case PATIENT -> User.of(
+                    dto.getEmail(),
+                    password,
+                    dto.getUsername(),
+                    0,
+                    false,
+                    UserRole.PATIENT
+            );
+        };
 
         userRepository.save(user);
 
@@ -94,10 +107,8 @@ public class AuthService {
         String refreshToken = jwtUtil.createRefreshToken(user.getId());
         // refreshToken을 Redis에 저장
         refreshTokenService.saveRefreshToken(user.getId(), refreshToken);
-        return UserSignInResponseDto.builder()
-                .accessToken(accessToken)
-                .refreshToken(refreshToken)
-                .build();
+
+        return UserSignInResponseDto.of(accessToken, refreshToken);
     }
 
     //토큰 재발급
@@ -105,19 +116,16 @@ public class AuthService {
     public UserRefreshTokenResponseDto refreshToken(AuthUser authuser, UserRefreshTokenRequestDto dto) {
         User user = userRepository.findById(authuser.getId())
                 .orElseThrow(() -> new ClientException(ErrorCode.USER_NOT_FOUND));
-        String token = jwtUtil.substringToken(dto.getRefreshToken());
-        Claims claims = jwtUtil.extractClaims(token);
+        String refreshToken = jwtUtil.substringToken(dto.getRefreshToken());
+        Claims claims = jwtUtil.extractClaims(refreshToken);
 
         String savedToken = refreshTokenService.getRefreshToken(user.getId());
-        if (!token.equals(savedToken)) {
+        if (!refreshToken.equals(savedToken)) {
             throw new ClientException(ErrorCode.INVALID_REFRESH_TOKEN);
         }
 
         String newAccessToken = jwtUtil.createToken(user.getId(), user.getUserRole());
 
-        return UserRefreshTokenResponseDto.builder()
-                .accessToken(newAccessToken)
-                .refreshToken(savedToken)
-                .build();
+        return UserRefreshTokenResponseDto.of(newAccessToken, refreshToken);
     }
 }

--- a/src/main/java/com/example/docconneting/domain/Auth/service/AuthService.java
+++ b/src/main/java/com/example/docconneting/domain/Auth/service/AuthService.java
@@ -1,4 +1,4 @@
-package com.example.docconneting.domain.Auth.authservice;
+package com.example.docconneting.domain.Auth.service;
 
 import com.example.docconneting.common.config.JwtUtil;
 import com.example.docconneting.common.config.PasswordEncoder;
@@ -6,6 +6,7 @@ import com.example.docconneting.common.enums.Major;
 import com.example.docconneting.common.exception.constant.ErrorCode;
 import com.example.docconneting.common.exception.object.ClientException;
 import com.example.docconneting.common.response.Response;
+import com.example.docconneting.domain.Auth.dto.AuthUser;
 import com.example.docconneting.domain.Auth.dto.request.UserRefreshTokenRequestDto;
 import com.example.docconneting.domain.Auth.dto.request.UserSignUpRequestDto;
 import com.example.docconneting.domain.Auth.dto.request.UserSigninRequestDto;
@@ -14,6 +15,7 @@ import com.example.docconneting.domain.Auth.dto.response.UserSignInResponseDto;
 import com.example.docconneting.domain.user.entity.User;
 import com.example.docconneting.domain.user.enums.UserRole;
 import com.example.docconneting.domain.user.repository.UserRepository;
+import io.jsonwebtoken.Claims;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -25,6 +27,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class AuthService {
 
+    private final RefreshTokenService refreshTokenService;
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
@@ -89,7 +92,8 @@ public class AuthService {
 
         String accessToken = jwtUtil.createToken(user.getId(), user.getUserRole());
         String refreshToken = jwtUtil.createRefreshToken(user.getId());
-
+        // refreshToken을 Redis에 저장
+        refreshTokenService.saveRefreshToken(user.getId(), refreshToken);
         return UserSignInResponseDto.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
@@ -98,7 +102,22 @@ public class AuthService {
 
     //토큰 재발급
     @Transactional
-    public UserRefreshTokenResponseDto refreshToken(UserRefreshTokenRequestDto requestDto) {
-        return null;
+    public UserRefreshTokenResponseDto refreshToken(AuthUser authuser, UserRefreshTokenRequestDto dto) {
+        User user = userRepository.findById(authuser.getId())
+                .orElseThrow(() -> new ClientException(ErrorCode.USER_NOT_FOUND));
+        String token = jwtUtil.substringToken(dto.getRefreshToken());
+        Claims claims = jwtUtil.extractClaims(token);
+
+        String savedToken = refreshTokenService.getRefreshToken(user.getId());
+        if (!token.equals(savedToken)) {
+            throw new ClientException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        String newAccessToken = jwtUtil.createToken(user.getId(), user.getUserRole());
+
+        return UserRefreshTokenResponseDto.builder()
+                .accessToken(newAccessToken)
+                .refreshToken(savedToken)
+                .build();
     }
 }

--- a/src/main/java/com/example/docconneting/domain/Auth/service/RefreshTokenService.java
+++ b/src/main/java/com/example/docconneting/domain/Auth/service/RefreshTokenService.java
@@ -16,13 +16,18 @@ public class RefreshTokenService {
 
     //refreshToken 저장
     public void saveRefreshToken(Long userId, String refreshToken) {
-        String pureRefreshToken = jwtUtil.substringToken(refreshToken);
-        redisTemplate.opsForValue().set("refreshToken:" + userId, pureRefreshToken, Duration.ofSeconds(REFRESH_TOKEN_EXPIRE_TIME));
+        redisTemplate.opsForValue().set("refreshToken:" + userId, refreshToken, Duration.ofSeconds(REFRESH_TOKEN_EXPIRE_TIME));
     }
 
     //refreshToken 찾기
     public String getRefreshToken(Long userId) {
         return redisTemplate.opsForValue().get("refreshToken:" + userId);
     }
+
+    //refreshToken 만료시간 확인
+    public Long getRefreshTokenTTL(Long userId) {
+        return redisTemplate.getExpire("refreshToken:" + userId);
+    }
+
 }
 

--- a/src/main/java/com/example/docconneting/domain/Auth/service/RefreshTokenService.java
+++ b/src/main/java/com/example/docconneting/domain/Auth/service/RefreshTokenService.java
@@ -1,0 +1,28 @@
+package com.example.docconneting.domain.Auth.service;
+
+import com.example.docconneting.common.config.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+    private final JwtUtil jwtUtil;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final long REFRESH_TOKEN_EXPIRE_TIME = 14 * 24 * 60 * 60;
+
+    //refreshToken 저장
+    public void saveRefreshToken(Long userId, String refreshToken) {
+        String pureRefreshToken = jwtUtil.substringToken(refreshToken);
+        redisTemplate.opsForValue().set("refreshToken:" + userId, pureRefreshToken, Duration.ofSeconds(REFRESH_TOKEN_EXPIRE_TIME));
+    }
+
+    //refreshToken 찾기
+    public String getRefreshToken(Long userId) {
+        return redisTemplate.opsForValue().get("refreshToken:" + userId);
+    }
+}
+

--- a/src/main/java/com/example/docconneting/domain/Auth/service/RefreshTokenService.java
+++ b/src/main/java/com/example/docconneting/domain/Auth/service/RefreshTokenService.java
@@ -4,6 +4,7 @@ import com.example.docconneting.common.config.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 
@@ -15,16 +16,19 @@ public class RefreshTokenService {
     private final long REFRESH_TOKEN_EXPIRE_TIME = 14 * 24 * 60 * 60;
 
     //refreshToken 저장
+    @Transactional
     public void saveRefreshToken(Long userId, String refreshToken) {
         redisTemplate.opsForValue().set("refreshToken:" + userId, refreshToken, Duration.ofSeconds(REFRESH_TOKEN_EXPIRE_TIME));
     }
 
     //refreshToken 찾기
+    @Transactional(readOnly = true)
     public String getRefreshToken(Long userId) {
         return redisTemplate.opsForValue().get("refreshToken:" + userId);
     }
 
     //refreshToken 만료시간 확인
+    @Transactional(readOnly = true)
     public Long getRefreshTokenTTL(Long userId) {
         return redisTemplate.getExpire("refreshToken:" + userId);
     }

--- a/src/main/java/com/example/docconneting/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/docconneting/domain/user/controller/UserController.java
@@ -3,9 +3,11 @@ package com.example.docconneting.domain.user.controller;
 import com.example.docconneting.common.response.Response;
 import com.example.docconneting.domain.Auth.annotation.Auth;
 import com.example.docconneting.domain.Auth.dto.AuthUser;
+import com.example.docconneting.domain.user.dto.request.UpdateImageRequestDto;
 import com.example.docconneting.domain.user.dto.request.UpdatePasswordRequestDto;
 import com.example.docconneting.domain.user.dto.response.UserMyPageResponseDto;
 import com.example.docconneting.domain.user.service.UserService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -14,7 +16,7 @@ import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/vi/users")
+@RequestMapping("/api/v1/users")
 public class UserController {
     private final UserService userService;
 
@@ -22,7 +24,7 @@ public class UserController {
     @GetMapping
     public ResponseEntity<Response<UserMyPageResponseDto>> findMyPage(
             @Auth AuthUser authUser
-            ){
+    ) {
         UserMyPageResponseDto response = userService.findMyPage(authUser);
         return ResponseEntity.ok(Response.of(response));
     }
@@ -31,10 +33,20 @@ public class UserController {
     @PatchMapping("/password")
     public ResponseEntity<Response<Map<String, String>>> updatePassword(
             @Auth AuthUser authUser,
-            @RequestBody UpdatePasswordRequestDto dto
-    ){
+            @Valid @RequestBody UpdatePasswordRequestDto dto
+    ) {
         Map<String, String> response = userService.updatePassword(authUser, dto);
         return ResponseEntity.ok(Response.of(response));
     }
-    //의사 프로필 이미지 수정
+
+    //의사 프로필 이미지 수정 (의사만 가능)
+    @PatchMapping("/profile")
+    public ResponseEntity<Response<Map<String, String>>> updateImage(
+            @Auth AuthUser authUser,
+            @Valid @RequestBody UpdateImageRequestDto dto
+    ) {
+        Map<String, String> response = userService.updateImage(authUser, dto);
+        return ResponseEntity.ok(Response.of(response));
+    }
+
 }

--- a/src/main/java/com/example/docconneting/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/docconneting/domain/user/controller/UserController.java
@@ -1,0 +1,40 @@
+package com.example.docconneting.domain.user.controller;
+
+import com.example.docconneting.common.response.Response;
+import com.example.docconneting.domain.Auth.annotation.Auth;
+import com.example.docconneting.domain.Auth.dto.AuthUser;
+import com.example.docconneting.domain.user.dto.request.UpdatePasswordRequestDto;
+import com.example.docconneting.domain.user.dto.response.UserMyPageResponseDto;
+import com.example.docconneting.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/vi/users")
+public class UserController {
+    private final UserService userService;
+
+    //마이페이지 조회
+    @GetMapping
+    public ResponseEntity<Response<UserMyPageResponseDto>> findMyPage(
+            @Auth AuthUser authUser
+            ){
+        UserMyPageResponseDto response = userService.findMyPage(authUser);
+        return ResponseEntity.ok(Response.of(response));
+    }
+
+    //비밀번호 수정
+    @PatchMapping("/password")
+    public ResponseEntity<Response<Map<String, String>>> updatePassword(
+            @Auth AuthUser authUser,
+            @RequestBody UpdatePasswordRequestDto dto
+    ){
+        Map<String, String> response = userService.updatePassword(authUser, dto);
+        return ResponseEntity.ok(Response.of(response));
+    }
+    //의사 프로필 이미지 수정
+}

--- a/src/main/java/com/example/docconneting/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/docconneting/domain/user/controller/UserController.java
@@ -2,7 +2,7 @@ package com.example.docconneting.domain.user.controller;
 
 import com.example.docconneting.common.response.Response;
 import com.example.docconneting.domain.Auth.annotation.Auth;
-import com.example.docconneting.domain.Auth.dto.AuthUser;
+import com.example.docconneting.domain.Auth.entity.AuthUser;
 import com.example.docconneting.domain.user.dto.request.UpdateImageRequestDto;
 import com.example.docconneting.domain.user.dto.request.UpdatePasswordRequestDto;
 import com.example.docconneting.domain.user.dto.response.UserMyPageResponseDto;

--- a/src/main/java/com/example/docconneting/domain/user/dto/request/UpdateImageRequestDto.java
+++ b/src/main/java/com/example/docconneting/domain/user/dto/request/UpdateImageRequestDto.java
@@ -1,0 +1,10 @@
+package com.example.docconneting.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class UpdateImageRequestDto {
+    @NotBlank(message = "신규 이미지는 필수사항입니다.")
+    private String newImage;
+}

--- a/src/main/java/com/example/docconneting/domain/user/dto/request/UpdatePasswordRequestDto.java
+++ b/src/main/java/com/example/docconneting/domain/user/dto/request/UpdatePasswordRequestDto.java
@@ -1,0 +1,13 @@
+package com.example.docconneting.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class UpdatePasswordRequestDto {
+    @NotBlank(message = "기존 비밀번호 입력은 필수입니다.")
+    private String oldPassword;
+
+    @NotBlank(message = "신규 비밀번호 입력은 필수입니다.")
+    private String newPassword;
+}

--- a/src/main/java/com/example/docconneting/domain/user/dto/response/UserMyPageResponseDto.java
+++ b/src/main/java/com/example/docconneting/domain/user/dto/response/UserMyPageResponseDto.java
@@ -8,10 +8,12 @@ public class UserMyPageResponseDto {
     private String username;
     private Integer point;
 
-    @Builder
-    public UserMyPageResponseDto(String username, Integer point)
-    {
+    private UserMyPageResponseDto(String username, Integer point) {
         this.username = username;
         this.point = point;
+    }
+
+    public static UserMyPageResponseDto of(String username, Integer point) {
+        return new UserMyPageResponseDto(username, point);
     }
 }

--- a/src/main/java/com/example/docconneting/domain/user/dto/response/UserMyPageResponseDto.java
+++ b/src/main/java/com/example/docconneting/domain/user/dto/response/UserMyPageResponseDto.java
@@ -1,6 +1,5 @@
 package com.example.docconneting.domain.user.dto.response;
 
-import lombok.Builder;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/example/docconneting/domain/user/dto/response/UserMyPageResponseDto.java
+++ b/src/main/java/com/example/docconneting/domain/user/dto/response/UserMyPageResponseDto.java
@@ -1,0 +1,17 @@
+package com.example.docconneting.domain.user.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class UserMyPageResponseDto {
+    private String username;
+    private Integer point;
+
+    @Builder
+    public UserMyPageResponseDto(String username, Integer point)
+    {
+        this.username = username;
+        this.point = point;
+    }
+}

--- a/src/main/java/com/example/docconneting/domain/user/entity/User.java
+++ b/src/main/java/com/example/docconneting/domain/user/entity/User.java
@@ -62,4 +62,14 @@ public class User extends BaseEntity {
         this.isDeleted = isDeleted;
         this.userRole = userRole;
     }
+
+    //비밀번호 setter
+    public void updatePassword(String newPassword) {
+        this.password = newPassword;
+    }
+
+    //의사 이미지 setter
+    public void updateImage(String newImage){
+        this.image = newImage;
+    }
 }

--- a/src/main/java/com/example/docconneting/domain/user/entity/User.java
+++ b/src/main/java/com/example/docconneting/domain/user/entity/User.java
@@ -54,7 +54,7 @@ public class User extends BaseEntity {
     }
 
     // 환자 생성 메서드
-    public static User of(String email, String password, String username, Integer point, Boolean isDeleted, UserRole userRole){
+    public static User of(String email, String password, String username, Integer point, Boolean isDeleted, UserRole userRole) {
         return new User(email, password, username, point, isDeleted, userRole);
     }
 
@@ -70,9 +70,9 @@ public class User extends BaseEntity {
         this.isDeleted = isDeleted;
         this.userRole = userRole;
     }
-  
+
     // 의사 생성 메서드
-    public static User of(String email, String password, String username, Major major, String image, LocalTime startTime, LocalTime endTime, Boolean isDeleted, UserRole userRole){
+    public static User of(String email, String password, String username, Major major, String image, LocalTime startTime, LocalTime endTime, Boolean isDeleted, UserRole userRole) {
         return new User(email, password, username, major, image, startTime, endTime, isDeleted, userRole);
     }
 
@@ -84,6 +84,6 @@ public class User extends BaseEntity {
     //의사 이미지 setter
     public void updateImage(String newImage) {
         this.image = newImage;
-    
-  
+    }
+
 }

--- a/src/main/java/com/example/docconneting/domain/user/entity/User.java
+++ b/src/main/java/com/example/docconneting/domain/user/entity/User.java
@@ -11,13 +11,14 @@ import java.time.LocalTime;
 
 @Entity
 @Table(name = "users",
-        indexes = { @Index(name = "idx1", columnList = "isDeleted"),
-                    @Index(name = "idx2", columnList = "major, isDeleted") }
+        indexes = {@Index(name = "idx1", columnList = "isDeleted"),
+                @Index(name = "idx2", columnList = "major, isDeleted")}
 )
 @Getter
 @NoArgsConstructor
 public class User extends BaseEntity {
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String email;
@@ -43,7 +44,7 @@ public class User extends BaseEntity {
     private Boolean isDeleted;
 
     // 환자 생성자
-    public User(String email, String password, String username, Integer point, Boolean isDeleted, UserRole userRole) {
+    private User(String email, String password, String username, Integer point, Boolean isDeleted, UserRole userRole) {
         this.email = email;
         this.password = password;
         this.username = username;
@@ -53,7 +54,7 @@ public class User extends BaseEntity {
     }
 
     // 의사 생성자
-    public User(String email, String password, String username, Major major, String image, LocalTime startTime, LocalTime endTime, Boolean isDeleted, UserRole userRole) {
+    private User(String email, String password, String username, Major major, String image, LocalTime startTime, LocalTime endTime, Boolean isDeleted, UserRole userRole) {
         this.email = email;
         this.password = password;
         this.username = username;
@@ -65,13 +66,23 @@ public class User extends BaseEntity {
         this.userRole = userRole;
     }
 
+    //환자 of
+    public static User of(String email, String password, String username, Integer point, Boolean isDeleted, UserRole userRole) {
+        return new User(email, password, username, point, isDeleted, userRole);
+    }
+
+    //의사 of
+    public static User of(String email, String password, String username, Major major, String image, LocalTime startTime, LocalTime endTime, Boolean isDeleted, UserRole userRole) {
+        return new User(email, password, username, major, image, startTime, endTime, isDeleted, userRole);
+    }
+
     //비밀번호 setter
     public void updatePassword(String newPassword) {
         this.password = newPassword;
     }
 
     //의사 이미지 setter
-    public void updateImage(String newImage){
+    public void updateImage(String newImage) {
         this.image = newImage;
     }
 }

--- a/src/main/java/com/example/docconneting/domain/user/enums/UserRole.java
+++ b/src/main/java/com/example/docconneting/domain/user/enums/UserRole.java
@@ -1,7 +1,20 @@
 package com.example.docconneting.domain.user.enums;
 
+import com.example.docconneting.common.enums.Major;
+import com.example.docconneting.common.exception.constant.ErrorCode;
+import com.example.docconneting.common.exception.object.ClientException;
+
 public enum UserRole {
     PATIENT,
     DOCTOR,
-    ADMIN
+    ADMIN;
+
+    public static UserRole of(String name) {
+        for (UserRole role: values()) {
+            if (role.name().equals(name)) {
+                return role;
+            }
+        }
+        throw new ClientException(ErrorCode.USERROLE_NOT_FOUND);
+    }
 }

--- a/src/main/java/com/example/docconneting/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/docconneting/domain/user/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package com.example.docconneting.domain.user.repository;
 
 import com.example.docconneting.domain.user.entity.User;
+import jakarta.validation.constraints.NotNull;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -13,4 +14,6 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
             "AND u.userRole = 'DOCTOR' " +
             "AND u.isDeleted = FALSE ")
     Optional<User> findByDoctorId(Long id);
+
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/example/docconneting/domain/user/service/UserService.java
+++ b/src/main/java/com/example/docconneting/domain/user/service/UserService.java
@@ -12,6 +12,7 @@ import com.example.docconneting.domain.user.enums.UserRole;
 import com.example.docconneting.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -24,6 +25,7 @@ public class UserService {
 
 
     //마이페이지 조회
+    @Transactional(readOnly = true)
     public UserMyPageResponseDto findMyPage(AuthUser authUser) {
         User user = userRepository.findById(authUser.getId()).orElseThrow(()-> new ClientException(ErrorCode.USER_NOT_FOUND));
 
@@ -31,6 +33,7 @@ public class UserService {
     }
 
     //비밀번호 수정
+    @Transactional
     public Map<String, String> updatePassword(AuthUser authUser, UpdatePasswordRequestDto dto) {
         User user = userRepository.findById(authUser.getId()).orElseThrow(()-> new ClientException(ErrorCode.USER_NOT_FOUND));
         if(!passwordEncoder.matches(dto.getOldPassword(),user.getPassword()))
@@ -47,6 +50,7 @@ public class UserService {
     }
 
     //의사 이미지 수정
+    @Transactional
     public Map<String, String> updateImage(AuthUser authUser, UpdateImageRequestDto dto) {
         User user = userRepository.findById(authUser.getId()).orElseThrow(()-> new ClientException(ErrorCode.USER_NOT_FOUND));
         if(!user.getUserRole().equals(UserRole.DOCTOR))

--- a/src/main/java/com/example/docconneting/domain/user/service/UserService.java
+++ b/src/main/java/com/example/docconneting/domain/user/service/UserService.java
@@ -1,0 +1,44 @@
+package com.example.docconneting.domain.user.service;
+
+import com.example.docconneting.common.config.PasswordEncoder;
+import com.example.docconneting.common.exception.constant.ErrorCode;
+import com.example.docconneting.common.exception.object.ClientException;
+import com.example.docconneting.domain.Auth.dto.AuthUser;
+import com.example.docconneting.domain.user.dto.request.UpdatePasswordRequestDto;
+import com.example.docconneting.domain.user.dto.response.UserMyPageResponseDto;
+import com.example.docconneting.domain.user.entity.User;
+import com.example.docconneting.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+
+    //마이페이지 조회
+    public UserMyPageResponseDto findMyPage(AuthUser authUser) {
+        User user = userRepository.findById(authUser.getId()).orElseThrow(()-> new ClientException(ErrorCode.USER_NOT_FOUND));
+
+        return UserMyPageResponseDto.builder()
+                .username(user.getUsername())
+                .point(user.getPoint())
+                .build();
+    }
+
+    //비밀번호 수정
+    public Map<String, String> updatePassword(AuthUser authUser, UpdatePasswordRequestDto dto) {
+        User user = userRepository.findById(authUser.getId()).orElseThrow(()-> new ClientException(ErrorCode.USER_NOT_FOUND));
+        if(!passwordEncoder.matches(dto.getOldPassword(),user.getPassword()))
+        {
+            throw new ClientException(ErrorCode.INVALID_PASSWORD);
+        }
+        
+        return null;
+    }
+}

--- a/src/main/java/com/example/docconneting/domain/user/service/UserService.java
+++ b/src/main/java/com/example/docconneting/domain/user/service/UserService.java
@@ -3,7 +3,7 @@ package com.example.docconneting.domain.user.service;
 import com.example.docconneting.common.config.PasswordEncoder;
 import com.example.docconneting.common.exception.constant.ErrorCode;
 import com.example.docconneting.common.exception.object.ClientException;
-import com.example.docconneting.domain.Auth.dto.AuthUser;
+import com.example.docconneting.domain.Auth.entity.AuthUser;
 import com.example.docconneting.domain.user.dto.request.UpdateImageRequestDto;
 import com.example.docconneting.domain.user.dto.request.UpdatePasswordRequestDto;
 import com.example.docconneting.domain.user.dto.response.UserMyPageResponseDto;
@@ -27,10 +27,7 @@ public class UserService {
     public UserMyPageResponseDto findMyPage(AuthUser authUser) {
         User user = userRepository.findById(authUser.getId()).orElseThrow(()-> new ClientException(ErrorCode.USER_NOT_FOUND));
 
-        return UserMyPageResponseDto.builder()
-                .username(user.getUsername())
-                .point(user.getPoint())
-                .build();
+        return UserMyPageResponseDto.of(user.getUsername(), user.getPoint());
     }
 
     //비밀번호 수정

--- a/src/main/java/com/example/docconneting/domain/user/service/UserService.java
+++ b/src/main/java/com/example/docconneting/domain/user/service/UserService.java
@@ -4,14 +4,16 @@ import com.example.docconneting.common.config.PasswordEncoder;
 import com.example.docconneting.common.exception.constant.ErrorCode;
 import com.example.docconneting.common.exception.object.ClientException;
 import com.example.docconneting.domain.Auth.dto.AuthUser;
+import com.example.docconneting.domain.user.dto.request.UpdateImageRequestDto;
 import com.example.docconneting.domain.user.dto.request.UpdatePasswordRequestDto;
 import com.example.docconneting.domain.user.dto.response.UserMyPageResponseDto;
 import com.example.docconneting.domain.user.entity.User;
+import com.example.docconneting.domain.user.enums.UserRole;
 import com.example.docconneting.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.web.bind.annotation.GetMapping;
 
+import java.util.HashMap;
 import java.util.Map;
 
 @Service
@@ -38,7 +40,25 @@ public class UserService {
         {
             throw new ClientException(ErrorCode.INVALID_PASSWORD);
         }
-        
-        return null;
+        if (dto.getOldPassword().equals(dto.getNewPassword())) {
+            throw new ClientException(ErrorCode.PASSWORD_SAME_AS_OLD);
+        }
+        user.updatePassword(passwordEncoder.encode(dto.getNewPassword()));
+        Map<String, String> message = new HashMap<>();
+        message.put("message","비밀 번호 수정이 성공적으로 됐습니다");
+        return message;
+    }
+
+    //의사 이미지 수정
+    public Map<String, String> updateImage(AuthUser authUser, UpdateImageRequestDto dto) {
+        User user = userRepository.findById(authUser.getId()).orElseThrow(()-> new ClientException(ErrorCode.USER_NOT_FOUND));
+        if(!user.getUserRole().equals(UserRole.DOCTOR))
+        {
+            throw new ClientException(ErrorCode.UNAUTHORIZED_USER);
+        }
+        user.updateImage(dto.getNewImage());
+        Map<String, String> message = new HashMap<>();
+        message.put("message","이미지 수정이 성공적으로 됐습니다");
+        return message;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,3 @@ logging:
 spring:
   profiles:
     active: local
-
-jwt:
-  secret:
-    key: rC1fZ3pYzPiNL2RzZHYtN3Q5MHJsT3pkZVNyT2lYa2M

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,3 +12,7 @@ logging:
 spring:
   profiles:
     active: local
+
+jwt:
+  secret:
+    key: rC1fZ3pYzPiNL2RzZHYtN3Q5MHJsT3pkZVNyT2lYa2M


### PR DESCRIPTION
#14 
- 회원가입, 로그인, 마이페이지 조회, 비밀번호 수정, 의사 이미지 수정, 토큰 재발급 기능 생성
- 리프레시 토큰 발급할때 bearer 제거
- 권한 이름 에러 - 400으로 수정
- 비밀번호 입력 에러 - 400으로 수정
- 이미지 입력 - 400
- 근무 시작/종료시간 - 400
- string쪽은 @notblank로 valid하기
 - 어세스 토큰 재발급시 리프레시 토큰 만료 확인 및 리프레시 토큰도 재발급하고 레디스에 업데이트
- 시크릿키 local로 옮기고 옮긴거 슬랙에 보고
- @Auth 익셉션 서버에러익셉션으로 처리
- @Transactional 및 readonly 추가