### PR TITLE
[#99] 알람 재시도 로직 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ out/
 *-prod.yml
 *-prod.properties
 
+### Firebase secret key ###
+*.json

--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,9 @@ dependencies {
 
     // Logstash
     implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
+
+    // spring cloud
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -81,8 +81,8 @@ dependencies {
     // 포트원 연동
     implementation 'com.github.iamport:iamport-rest-client-java:0.2.21'
 
-    // spring cloud
-    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    // Firebase
+    implementation 'com.google.firebase:firebase-admin:9.2.0'
 
     // rabbitMQ 연결
     implementation 'org.springframework.boot:spring-boot-starter-amqp'
@@ -90,7 +90,7 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-reactor-netty'
 
-    // 일라스틱 서치
+    // Elasticsearch
     implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
 
     // Logstash

--- a/src/main/java/com/example/docconneting/DocconnetingApplication.java
+++ b/src/main/java/com/example/docconneting/DocconnetingApplication.java
@@ -6,7 +6,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchDataAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.data.elasticsearch.config.EnableElasticsearchAuditing;
-import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -19,7 +18,6 @@ import static org.springframework.data.web.config.EnableSpringDataWebSupport.Pag
 @EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)
 @EnableConfigurationProperties(PortOneProperties.class)
 @EnableElasticsearchAuditing
-@EnableDiscoveryClient
 public class DocconnetingApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/docconneting/common/config/AsyncConfig.java
+++ b/src/main/java/com/example/docconneting/common/config/AsyncConfig.java
@@ -1,0 +1,38 @@
+package com.example.docconneting.common.config;
+
+import com.example.docconneting.common.exception.constant.ErrorCode;
+import com.example.docconneting.common.exception.object.ServerException;
+import com.example.docconneting.common.exceptionhandler.CustomAsyncExceptionHandler;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Bean(name = "fcmExecutor")
+    public Executor fcmExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(4);
+        executor.setMaxPoolSize(6);
+        executor.setQueueCapacity(100);
+        executor.setKeepAliveSeconds(60);
+        executor.setThreadNamePrefix("FCM-Async-");
+        executor.setRejectedExecutionHandler((r, exec) -> {
+            throw new ServerException(ErrorCode.TOO_MANY_REQUESTS);
+        });
+        executor.initialize();
+        return executor;
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return new CustomAsyncExceptionHandler();
+    }
+}

--- a/src/main/java/com/example/docconneting/common/config/FcmInitializer.java
+++ b/src/main/java/com/example/docconneting/common/config/FcmInitializer.java
@@ -1,0 +1,37 @@
+package com.example.docconneting.common.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+@Slf4j
+@Component
+public class FcmInitializer {
+
+    @Value("${fcm.certification}")
+    private String googleApplicationCredentials;
+
+    @PostConstruct
+    public void initialize() throws IOException {
+        ClassPathResource resource = new ClassPathResource(googleApplicationCredentials);
+
+        try (InputStream is = resource.getInputStream()) {
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(is))
+                    .build();
+
+            if (FirebaseApp.getApps().isEmpty()) {
+                FirebaseApp.initializeApp(options);
+                log.info("FirebaseApp initialization complete");
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/docconneting/common/exception/constant/ErrorCode.java
+++ b/src/main/java/com/example/docconneting/common/exception/constant/ErrorCode.java
@@ -141,6 +141,9 @@ public enum ErrorCode {
     // 429
     TOO_MANY_REQUESTS(HttpStatus.TOO_MANY_REQUESTS, "N001", "요청이 너무 많아 더 이상 요청을 처리할 수 없습니다."),
 
+    // 503
+    FCM_SEND_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "N002", "FCM 서버 문제로 알림 전송에 실패했습니다."),
+
     // 결제 에러코드 P
 
     // 400

--- a/src/main/java/com/example/docconneting/common/exceptionhandler/CustomAsyncExceptionHandler.java
+++ b/src/main/java/com/example/docconneting/common/exceptionhandler/CustomAsyncExceptionHandler.java
@@ -1,0 +1,19 @@
+package com.example.docconneting.common.exceptionhandler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+
+import java.lang.reflect.Method;
+
+@Slf4j
+public class CustomAsyncExceptionHandler implements AsyncUncaughtExceptionHandler {
+    @Override
+    public void handleUncaughtException(Throwable ex, Method method, Object... obj) {
+        log.info("예외 메시지: {}", ex.getMessage());
+        log.info("예외 발생 메서드: {}", method.getName());
+
+        for (Object param : obj) {
+            log.info("파라미터 값 : {}", param);
+        }
+    }
+}

--- a/src/main/java/com/example/docconneting/domain/alarm/controller/AlarmController.java
+++ b/src/main/java/com/example/docconneting/domain/alarm/controller/AlarmController.java
@@ -1,0 +1,32 @@
+package com.example.docconneting.domain.alarm.controller;
+
+import com.example.docconneting.common.response.PageResult;
+import com.example.docconneting.common.response.Response;
+import com.example.docconneting.domain.alarm.dto.AlarmResponse;
+import com.example.docconneting.domain.alarm.service.AlarmService;
+import com.example.docconneting.domain.auth.annotation.Auth;
+import com.example.docconneting.domain.auth.entity.AuthUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/notifications")
+@RequiredArgsConstructor
+public class AlarmController {
+
+    private final AlarmService alarmService;
+
+    @GetMapping()
+    public ResponseEntity<Response<List<AlarmResponse>>> findAlarmHistories(@Auth AuthUser authUser, @PageableDefault Pageable pageable) {
+        PageResult<AlarmResponse> pageResult = alarmService.findAlarms(authUser, pageable);
+        return ResponseEntity.ok().body(Response.of(pageResult.getContent(), pageResult.getPageInfo()));
+    }
+
+}

--- a/src/main/java/com/example/docconneting/domain/alarm/dto/AlarmResponse.java
+++ b/src/main/java/com/example/docconneting/domain/alarm/dto/AlarmResponse.java
@@ -1,0 +1,38 @@
+package com.example.docconneting.domain.alarm.dto;
+
+import com.example.docconneting.domain.alarm.entity.AlarmHistories;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+public class AlarmResponse {
+
+    private final Long id;
+    private final String content;
+    private final String alarmType;
+    private final LocalDateTime createdAt;
+
+    private AlarmResponse(Long id, String content, String alarmType, LocalDateTime createdAt) {
+        this.id = id;
+        this.content = content;
+        this.alarmType = alarmType;
+        this.createdAt = createdAt;
+    }
+
+    public static AlarmResponse of (Long id, String content, String alarmType, LocalDateTime createdAt) {
+        return new AlarmResponse(id, content, alarmType, createdAt);
+    }
+
+    public static List<AlarmResponse> toAlarmResponse(List<AlarmHistories> alarmHistoriesList) {
+        List<AlarmResponse> alarmResponseList = alarmHistoriesList.stream()
+                .map(alarmHistories -> new AlarmResponse(
+                        alarmHistories.getId(),
+                        alarmHistories.getContent(),
+                        alarmHistories.getAlarmType().name(),
+                        alarmHistories.getCreatedAt()))
+                .toList();
+        return alarmResponseList;
+    }
+}

--- a/src/main/java/com/example/docconneting/domain/alarm/entity/AlarmHistories.java
+++ b/src/main/java/com/example/docconneting/domain/alarm/entity/AlarmHistories.java
@@ -1,0 +1,44 @@
+package com.example.docconneting.domain.alarm.entity;
+
+import com.example.docconneting.domain.alarm.enums.AlarmType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "alarm_histories")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class AlarmHistories {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String content;
+
+    private Long toId;
+
+    @Enumerated(EnumType.STRING)
+    private AlarmType alarmType;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    private AlarmHistories(String content, Long toId, AlarmType alarmType) {
+        this.content = content;
+        this.toId = toId;
+        this.alarmType = alarmType;
+    }
+
+    public static AlarmHistories of(String content, Long toId, AlarmType alarmType) {
+        return new AlarmHistories(content, toId, alarmType);
+    }
+}
+

--- a/src/main/java/com/example/docconneting/domain/alarm/repository/AlarmHistoriesBulkRepository.java
+++ b/src/main/java/com/example/docconneting/domain/alarm/repository/AlarmHistoriesBulkRepository.java
@@ -1,0 +1,33 @@
+package com.example.docconneting.domain.alarm.repository;
+
+import com.example.docconneting.domain.alarm.enums.AlarmType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.sql.PreparedStatement;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class AlarmHistoriesBulkRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public int[][] batchUpdate(List<Long> userIdList, AlarmType alarmType, String content) {
+        int [][] insertCount = jdbcTemplate.batchUpdate(
+                "INSERT INTO alarm_histories(content, to_id, alarm_type, created_at)" + "VALUES (?, ?, ?, ?)",
+                userIdList,
+                100,
+                (PreparedStatement ps, Long userId) -> {
+                    ps.setString(1, content);
+                    ps.setString(2, String.valueOf(userId));
+                    ps.setString(3, String.valueOf(alarmType));
+                    ps.setTimestamp(4, Timestamp.valueOf(LocalDateTime.now()));
+                });
+        return insertCount;
+    }
+
+}

--- a/src/main/java/com/example/docconneting/domain/alarm/repository/AlarmHistoriesRepository.java
+++ b/src/main/java/com/example/docconneting/domain/alarm/repository/AlarmHistoriesRepository.java
@@ -1,0 +1,7 @@
+package com.example.docconneting.domain.alarm.repository;
+
+import com.example.docconneting.domain.alarm.entity.AlarmHistories;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AlarmHistoriesRepository extends JpaRepository<AlarmHistories, Long>, AlarmHistoriesRepositoryQuery {
+}

--- a/src/main/java/com/example/docconneting/domain/alarm/repository/AlarmHistoriesRepositoryQuery.java
+++ b/src/main/java/com/example/docconneting/domain/alarm/repository/AlarmHistoriesRepositoryQuery.java
@@ -1,0 +1,10 @@
+package com.example.docconneting.domain.alarm.repository;
+
+import com.example.docconneting.domain.alarm.entity.AlarmHistories;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface AlarmHistoriesRepositoryQuery {
+
+    Page<AlarmHistories> findAlarmHistories(Long userId, Pageable pageable);
+}

--- a/src/main/java/com/example/docconneting/domain/alarm/repository/AlarmHistoriesRepositoryQueryImpl.java
+++ b/src/main/java/com/example/docconneting/domain/alarm/repository/AlarmHistoriesRepositoryQueryImpl.java
@@ -1,0 +1,37 @@
+package com.example.docconneting.domain.alarm.repository;
+
+import com.example.docconneting.domain.alarm.entity.AlarmHistories;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+import java.util.List;
+
+import static com.example.docconneting.domain.alarm.entity.QAlarmHistories.alarmHistories;
+
+@RequiredArgsConstructor
+public class AlarmHistoriesRepositoryQueryImpl implements AlarmHistoriesRepositoryQuery {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Page<AlarmHistories> findAlarmHistories(Long userId, Pageable pageable) {
+        List<AlarmHistories> alarmHistoyList = jpaQueryFactory
+                .select(alarmHistories)
+                .from(alarmHistories)
+                .where(alarmHistories.toId.eq(userId))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(alarmHistories.createdAt.desc())
+                .fetch();
+
+        JPAQuery<Long> countQuery = jpaQueryFactory
+                .select(alarmHistories.count())
+                .from(alarmHistories);
+
+        return PageableExecutionUtils.getPage(alarmHistoyList, pageable, countQuery::fetchOne);
+    }
+}

--- a/src/main/java/com/example/docconneting/domain/alarm/service/AlarmSenderService.java
+++ b/src/main/java/com/example/docconneting/domain/alarm/service/AlarmSenderService.java
@@ -1,61 +1,60 @@
 package com.example.docconneting.domain.alarm.service;
 
-import com.example.docconneting.common.enums.Major;
-import com.example.docconneting.domain.alarm.enums.AlarmType;
-import com.example.docconneting.domain.user.entity.User;
-import com.example.docconneting.domain.user.repository.UserRepository;
-import com.example.docconneting.infra.rabbitmq.dto.FcmInfo;
-import com.example.docconneting.infra.rabbitmq.dto.Message;
-import com.example.docconneting.infra.rabbitmq.producer.AlarmServerSender;
-import lombok.RequiredArgsConstructor;
+import com.google.firebase.messaging.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+@Slf4j
 @Service
-@RequiredArgsConstructor
 public class AlarmSenderService {
 
-    private final UserRepository userRepository;
-    private final AlarmServerSender alarmServerSender;
-
     /*
-     * 사용자가 유료 게시물을 올렸을 떄 해당 전공에 해당되는 의사들에게 알람 전송
+     * 다건 알람 전송
      */
-    @Transactional
-    public void sendPostUploadCompletedMessage(Major major) {
-        List<User> users = userRepository.findByMajor(major);
-        List<FcmInfo> fcmInfoList = users.stream()
-                                    .map(user -> FcmInfo.of(user.getFcmToken(), user.getId()))
-                                    .toList();
+    @Async("fcmExecutor")
+    public void sendMulticastAlarm(List<String> fcmTokenBatche, String content) {
+        try {
+            MulticastMessage message = MulticastMessage.builder()
+                    .setNotification(Notification.builder()
+                            .setTitle("Docconneting")
+                            .setBody(content)
+                            .build())
+                    .addAllTokens(fcmTokenBatche)
+                    .build();
 
-        Message messageDto = Message.of(fcmInfoList, "새로운 유료 질문이 등록되었습니다", AlarmType.POST_UPLOAD);
-        alarmServerSender.send(messageDto);
+            BatchResponse response = FirebaseMessaging.getInstance().sendEachForMulticast(message);
+
+            int successCount = response.getSuccessCount();
+            int failureCount = response.getFailureCount();
+
+            log.info("알림 전송 완료 - 성공횟수: {}, 실패횟수: {}", successCount, failureCount);
+        } catch (FirebaseMessagingException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /*
-     * 게시물에 의사가 댓글을 달았을 때 게시물 작성자에게 알람 전송
+     * 단건 알람 전송
      */
-    @Transactional
-    public void sendCommentCompletedMessage(User user) {
-        FcmInfo fcmInfo = FcmInfo.of(user.getFcmToken(), user.getId());
-        List<FcmInfo> fcmInfoList = List.of(fcmInfo);
-        String message = "회원님의 게시물에 의사가 답변을 달았습니다";
-        Message messageDto = Message.of(fcmInfoList, message, AlarmType.COMMENT);
-        alarmServerSender.send(messageDto);
-    }
+    @Async("fcmExecutor")
+    public void sendAlarm(String fcmToken, String content) {
+        try {
+            com.google.firebase.messaging.Message message = Message.builder()
+                    .setToken(fcmToken)
+                    .setNotification(Notification.builder()
+                            .setTitle("Docconneting")
+                            .setBody(content)
+                            .build())
+                    .build();
 
-    /*
-     * 채팅 진료 결제가 완료 됐을 때 해당 의사에게 알람 전송
-     */
-    @Transactional
-    public void sendMedicalRequestMessage(User patient, User doctor) {
-        FcmInfo fcmInfo = FcmInfo.of(doctor.getFcmToken(), doctor.getId());
-        List<FcmInfo> fcmInfoList = List.of(fcmInfo);
-        String message = patient.getUsername() + "님이 채팅 진료를 요청 했습니다";
-        Message messageDto = Message.of(fcmInfoList, message, AlarmType.MEDICAL_REQUEST);
-        alarmServerSender.send(messageDto);
+            String response = FirebaseMessaging.getInstance().send(message);
+            log.info("알림 전송 완료 - 메시지 ID: {}", response);
+        } catch (FirebaseMessagingException e) {
+            throw new RuntimeException(e);
+        }
     }
 
 }

--- a/src/main/java/com/example/docconneting/domain/alarm/service/AlarmSenderService.java
+++ b/src/main/java/com/example/docconneting/domain/alarm/service/AlarmSenderService.java
@@ -1,15 +1,26 @@
 package com.example.docconneting.domain.alarm.service;
 
+import com.example.docconneting.common.exception.constant.ErrorCode;
+import com.example.docconneting.common.exception.object.ServerException;
 import com.google.firebase.messaging.*;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+import static com.google.firebase.messaging.MessagingErrorCode.*;
+
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class AlarmSenderService {
+
+    private final FcmTokenService fcmTokenService;
 
     /*
      * 다건 알람 전송
@@ -40,9 +51,14 @@ public class AlarmSenderService {
      * 단건 알람 전송
      */
     @Async("fcmExecutor")
+    @Retryable(
+            retryFor = ServerException.class,
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 1000, multiplier = 2)
+    )
     public void sendAlarm(String fcmToken, String content) {
         try {
-            com.google.firebase.messaging.Message message = Message.builder()
+            Message message = Message.builder()
                     .setToken(fcmToken)
                     .setNotification(Notification.builder()
                             .setTitle("Docconneting")
@@ -52,9 +68,28 @@ public class AlarmSenderService {
 
             String response = FirebaseMessaging.getInstance().send(message);
             log.info("알림 전송 완료 - 메시지 ID: {}", response);
-        } catch (FirebaseMessagingException e) {
-            throw new RuntimeException(e);
+        } catch (FirebaseMessagingException exception) {
+            MessagingErrorCode errorCode = exception.getMessagingErrorCode();
+
+            if (errorCode.equals(INTERNAL) || errorCode.equals(UNAVAILABLE)) {
+                log.info("FCM 서버 내부 오류 발생 - 알람 전송 재시도");
+                throw new ServerException(ErrorCode.FCM_SEND_FAILED);
+            }
+
+            if (errorCode.equals(INVALID_ARGUMENT) || errorCode.equals(UNREGISTERED)) {
+                log.info("FCM 토큰 이상 발생 - 토큰 제거");
+                fcmTokenService.deleteFcmToken(fcmToken);
+            }
+
+            if (errorCode.equals(THIRD_PARTY_AUTH_ERROR) || errorCode.equals(SENDER_ID_MISMATCH)) {
+                log.info("서버 설정/인증서 문제 발생 - 서버 확인 필요");
+            }
         }
+    }
+
+    @Recover
+    public void recover(ServerException exception, String fcmToken, String content) {
+        log.info("FCM 알림 재시도 3회 실패 - token : {}, content : {}", fcmToken, content);
     }
 
 }

--- a/src/main/java/com/example/docconneting/domain/alarm/service/AlarmSenderService.java
+++ b/src/main/java/com/example/docconneting/domain/alarm/service/AlarmSenderService.java
@@ -56,17 +56,17 @@ public class AlarmSenderService {
                         MessagingErrorCode errorCode = exception.getMessagingErrorCode();
 
                         if (errorCode.equals(INTERNAL) || errorCode.equals(UNAVAILABLE)) {
-                            log.info("FCM 서버 내부 오류 발생 - 알람 전송 재시도 리스트에 추가");
+                            log.error("FCM 서버 내부 오류 발생 - 알람 전송 재시도 리스트에 추가");
                             failedTokens.add(fcmToken);
                         }
 
                         if (errorCode.equals(INVALID_ARGUMENT) || errorCode.equals(UNREGISTERED)) {
-                            log.info("FCM 토큰 이상 발생 - 토큰 제거");
+                            log.error("FCM 토큰 이상 발생 - 토큰 제거");
                             fcmTokenService.deleteFcmToken(fcmToken);
                         }
 
                         if (errorCode.equals(THIRD_PARTY_AUTH_ERROR) || errorCode.equals(SENDER_ID_MISMATCH)) {
-                            log.info("서버 설정/인증서 문제 발생 - 서버 확인 필요");
+                            log.error("서버 설정/인증서 문제 발생 - 서버 확인 필요");
                         }
                     }
                 }
@@ -80,14 +80,14 @@ public class AlarmSenderService {
                 attempt++;
 
             } catch (FirebaseMessagingException e) {
-                log.info("알람 전체 전송 실패 - {}", e.getMessagingErrorCode());
+                log.error("알람 전체 전송 실패 - {}", e.getMessagingErrorCode());
                 return;
             }
 
         }
 
         if (!targets.isEmpty()) {
-            log.info("알람 전송 최종 실패 명수 - {}", targets.size());
+            log.error("알람 전송 최종 실패 명수 - {}", targets.size());
         }
     }
 
@@ -116,17 +116,17 @@ public class AlarmSenderService {
             MessagingErrorCode errorCode = exception.getMessagingErrorCode();
 
             if (errorCode.equals(INTERNAL) || errorCode.equals(UNAVAILABLE)) {
-                log.info("FCM 서버 내부 오류 발생 - 알람 전송 재시도");
+                log.error("FCM 서버 내부 오류 발생 - 알람 전송 재시도");
                 throw new ServerException(ErrorCode.FCM_SEND_FAILED);
             }
 
             if (errorCode.equals(INVALID_ARGUMENT) || errorCode.equals(UNREGISTERED)) {
-                log.info("FCM 토큰 이상 발생 - 토큰 제거");
+                log.error("FCM 토큰 이상 발생 - 토큰 제거");
                 fcmTokenService.deleteFcmToken(fcmToken);
             }
 
             if (errorCode.equals(THIRD_PARTY_AUTH_ERROR) || errorCode.equals(SENDER_ID_MISMATCH)) {
-                log.info("서버 설정/인증서 문제 발생 - 서버 확인 필요");
+                log.error("서버 설정/인증서 문제 발생 - 서버 확인 필요");
             }
         }
     }

--- a/src/main/java/com/example/docconneting/domain/alarm/service/AlarmSenderService.java
+++ b/src/main/java/com/example/docconneting/domain/alarm/service/AlarmSenderService.java
@@ -11,6 +11,7 @@ import org.springframework.retry.annotation.Retryable;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.google.firebase.messaging.MessagingErrorCode.*;
@@ -27,23 +28,66 @@ public class AlarmSenderService {
      */
     @Async("fcmExecutor")
     public void sendMulticastAlarm(List<String> fcmTokenBatche, String content) {
-        try {
+        List<String> targets = new ArrayList<>(fcmTokenBatche);
+        int maxAttempts = 3;
+        int attempt = 1;
+
+        while (attempt <= maxAttempts && !targets.isEmpty()) {
             MulticastMessage message = MulticastMessage.builder()
                     .setNotification(Notification.builder()
                             .setTitle("Docconneting")
                             .setBody(content)
                             .build())
-                    .addAllTokens(fcmTokenBatche)
+                    .addAllTokens(targets)
                     .build();
 
-            BatchResponse response = FirebaseMessaging.getInstance().sendEachForMulticast(message);
+            try {
+                BatchResponse response = FirebaseMessaging.getInstance().sendEachForMulticast(message);
 
-            int successCount = response.getSuccessCount();
-            int failureCount = response.getFailureCount();
+                List<String> failedTokens = new ArrayList<>();
+                List<SendResponse> responses = response.getResponses();
 
-            log.info("알림 전송 완료 - 성공횟수: {}, 실패횟수: {}", successCount, failureCount);
-        } catch (FirebaseMessagingException e) {
-            throw new RuntimeException(e);
+                for (int i = 0; i < responses.size(); i++) {
+                    SendResponse sendResponse = responses.get(i);
+                    String fcmToken = targets.get(i);
+
+                    if (!sendResponse.isSuccessful()) {
+                        FirebaseMessagingException exception = (FirebaseMessagingException) sendResponse.getException();
+                        MessagingErrorCode errorCode = exception.getMessagingErrorCode();
+
+                        if (errorCode.equals(INTERNAL) || errorCode.equals(UNAVAILABLE)) {
+                            log.info("FCM 서버 내부 오류 발생 - 알람 전송 재시도 리스트에 추가");
+                            failedTokens.add(fcmToken);
+                        }
+
+                        if (errorCode.equals(INVALID_ARGUMENT) || errorCode.equals(UNREGISTERED)) {
+                            log.info("FCM 토큰 이상 발생 - 토큰 제거");
+                            fcmTokenService.deleteFcmToken(fcmToken);
+                        }
+
+                        if (errorCode.equals(THIRD_PARTY_AUTH_ERROR) || errorCode.equals(SENDER_ID_MISMATCH)) {
+                            log.info("서버 설정/인증서 문제 발생 - 서버 확인 필요");
+                        }
+                    }
+                }
+
+                if (failedTokens.isEmpty()) {
+                    log.info("알림 전송 완료 - 성공횟수 : {}, 실패횟수 : {}", response.getSuccessCount(), response.getFailureCount());
+                    return;
+                }
+
+                targets = failedTokens;
+                attempt++;
+
+            } catch (FirebaseMessagingException e) {
+                log.info("알람 전체 전송 실패 - {}", e.getMessagingErrorCode());
+                return;
+            }
+
+        }
+
+        if (!targets.isEmpty()) {
+            log.info("알람 전송 최종 실패 명수 - {}", targets.size());
         }
     }
 

--- a/src/main/java/com/example/docconneting/domain/alarm/service/AlarmService.java
+++ b/src/main/java/com/example/docconneting/domain/alarm/service/AlarmService.java
@@ -1,0 +1,114 @@
+package com.example.docconneting.domain.alarm.service;
+
+import com.example.docconneting.common.enums.Major;
+import com.example.docconneting.common.response.PageInfo;
+import com.example.docconneting.common.response.PageResult;
+import com.example.docconneting.domain.alarm.dto.AlarmResponse;
+import com.example.docconneting.domain.alarm.entity.AlarmHistories;
+import com.example.docconneting.domain.alarm.enums.AlarmType;
+import com.example.docconneting.domain.alarm.repository.AlarmHistoriesBulkRepository;
+import com.example.docconneting.domain.alarm.repository.AlarmHistoriesRepository;
+import com.example.docconneting.domain.auth.entity.AuthUser;
+import com.example.docconneting.domain.user.entity.User;
+import com.example.docconneting.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class AlarmService {
+
+    private final AlarmSenderService alarmSenderService;
+    private final UserRepository userRepository;
+    private final AlarmHistoriesRepository alarmHistoriesRepository;
+    private final AlarmHistoriesBulkRepository alarmHistoriesBulkRepository;
+
+    /*
+     * 알람 목록 조회
+     */
+    @Transactional(readOnly = true)
+    public PageResult<AlarmResponse> findAlarms(AuthUser authUser, Pageable pageable) {
+        Page<AlarmHistories> result = alarmHistoriesRepository.findAlarmHistories(authUser.getId(), pageable);
+        List<AlarmResponse> alarms = AlarmResponse.toAlarmResponse(result.getContent());
+
+        PageInfo pageInfo = PageInfo.builder()
+                .pageNum(pageable.getPageNumber())
+                .pageSize(pageable.getPageSize())
+                .totalElement(result.getTotalElements())
+                .totalPage(result.getTotalPages())
+                .build();
+
+        return new PageResult<>(alarms, pageInfo);
+    }
+
+    /*
+     * 사용자가 유료 게시물을 올렸을 떄 해당 전공에 해당되는 의사들에게 알람 전송
+     */
+    @Transactional
+    public void sendPostUploadCompletedMessage(Major major) {
+        List<User> users = userRepository.findByMajor(major);
+        List<String> fcmTokenList = users.stream()
+                .map(User::getFcmToken)
+                .toList();
+
+        List<Long> userIdList = users.stream()
+                .map(User::getId)
+                .toList();
+
+        AlarmType alarmType = AlarmType.POST_UPLOAD;
+        String alarmMessage = "새로운 유료 질문이 들어왔습니다.";
+
+
+        List<List<String>> fcmTokenBatches = new ArrayList<>();
+        for (int i = 0; i < fcmTokenList.size(); i += 100) {
+            fcmTokenBatches.add(fcmTokenList.subList(i, Math.min(fcmTokenList.size(), i + 100)));
+        }
+        for (List<String> fcmTokenBatche : fcmTokenBatches) {
+            alarmSenderService.sendMulticastAlarm(fcmTokenBatche, alarmMessage);
+        }
+        alarmHistoriesBulkRepository.batchUpdate(userIdList, alarmType, alarmMessage);
+    }
+
+    /*
+     * 게시물에 의사가 댓글을 달았을 때 게시물 작성자에게 알람 전송
+     */
+    @Transactional
+    public void sendCommentCompletedMessage(User user) {
+        String fcmToken = user.getFcmToken();
+        Long userId = user.getId();
+        AlarmType alarmType = AlarmType.COMMENT;
+        String alarmMessage = "회원님의 게시물에 의사가 댓글을 달았습니다.";
+
+        alarmSenderService.sendAlarm(fcmToken, alarmMessage);
+        saveAlarmHistories(alarmMessage, userId, alarmType);
+    }
+
+    /*
+     * 채팅 진료 결제가 완료 됐을 때 해당 의사에게 알람 전송
+     */
+    @Transactional
+    public void sendMedicalRequestMessage(User patient, User doctor) {
+        String fcmToken = doctor.getFcmToken();
+        Long userId = doctor.getId();
+        String alarmMessage = patient.getUsername() + "님이 채팅 진료를 요청 했습니다";
+
+        alarmSenderService.sendAlarm(fcmToken, alarmMessage);
+        saveAlarmHistories(alarmMessage, userId, AlarmType.MEDICAL_REQUEST);
+    }
+
+    /*
+     * 단건 알람 히스토리 저장
+     */
+    private void saveAlarmHistories(String content, Long id, AlarmType alarmType) {
+        AlarmHistories alarmHistories = AlarmHistories.of(content, id, alarmType);
+        alarmHistoriesRepository.save(alarmHistories);
+    }
+}

--- a/src/main/java/com/example/docconneting/domain/alarm/service/AlarmService.java
+++ b/src/main/java/com/example/docconneting/domain/alarm/service/AlarmService.java
@@ -21,8 +21,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 
-@Service
 @Slf4j
+@Service
 @RequiredArgsConstructor
 public class AlarmService {
 
@@ -111,4 +111,5 @@ public class AlarmService {
         AlarmHistories alarmHistories = AlarmHistories.of(content, id, alarmType);
         alarmHistoriesRepository.save(alarmHistories);
     }
+
 }

--- a/src/main/java/com/example/docconneting/domain/alarm/service/FcmTokenService.java
+++ b/src/main/java/com/example/docconneting/domain/alarm/service/FcmTokenService.java
@@ -1,0 +1,26 @@
+package com.example.docconneting.domain.alarm.service;
+
+import com.example.docconneting.common.exception.constant.ErrorCode;
+import com.example.docconneting.common.exception.object.ClientException;
+import com.example.docconneting.domain.user.entity.User;
+import com.example.docconneting.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class FcmTokenService {
+
+    private final UserRepository userRepository;
+
+    /*
+     * 유효하지 않은 FCM 토큰을 가진 사용자의 FCM 토큰을 제거
+     */
+    @Transactional
+    public void deleteFcmToken(String fcmToken) {
+        User user = userRepository.findByFcmToken(fcmToken).orElseThrow(() -> new ClientException(ErrorCode.USER_NOT_FOUND));
+        user.deleteFcmToken();
+    }
+
+}

--- a/src/main/java/com/example/docconneting/domain/comment/service/CommentService.java
+++ b/src/main/java/com/example/docconneting/domain/comment/service/CommentService.java
@@ -1,14 +1,14 @@
 package com.example.docconneting.domain.comment.service;
 
 import com.example.docconneting.common.exception.constant.ErrorCode;
-import com.example.docconneting.common.exception.object.ServerException;
-import com.example.docconneting.domain.alarm.service.AlarmSenderService;
-import com.example.docconneting.domain.comment.dto.request.CommentRequest;
-import com.example.docconneting.domain.comment.dto.response.CommentResponse;
 import com.example.docconneting.common.exception.object.ClientException;
+import com.example.docconneting.common.exception.object.ServerException;
 import com.example.docconneting.common.response.PageInfo;
 import com.example.docconneting.common.response.PageResult;
+import com.example.docconneting.domain.alarm.service.AlarmService;
+import com.example.docconneting.domain.comment.dto.request.CommentRequest;
 import com.example.docconneting.domain.comment.dto.response.CommentListResponse;
+import com.example.docconneting.domain.comment.dto.response.CommentResponse;
 import com.example.docconneting.domain.comment.entity.Comment;
 import com.example.docconneting.domain.comment.repository.CommentRepository;
 import com.example.docconneting.domain.post.entity.Post;
@@ -16,7 +16,6 @@ import com.example.docconneting.domain.post.repository.PostRepository;
 import com.example.docconneting.domain.user.entity.User;
 import com.example.docconneting.domain.user.enums.UserRole;
 import com.example.docconneting.domain.user.repository.UserRepository;
-
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -30,7 +29,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class CommentService {
 
-    private final AlarmSenderService alarmSenderService;
+    private final AlarmService alarmService;
     private final CommentRepository commentRepository;
     private final PostRepository postRepository;
     private final UserRepository userRepository;
@@ -53,7 +52,7 @@ public class CommentService {
         Comment saved = commentRepository.save(comment);
 
         // 게시물 작성자에게 알람 전송
-        alarmSenderService.sendCommentCompletedMessage(post.getPatient());
+        alarmService.sendCommentCompletedMessage(post.getPatient());
 
         CommentResponse response = CommentResponse.of(
                 comment.getId(),

--- a/src/main/java/com/example/docconneting/domain/payment/service/PaymentApplicationService.java
+++ b/src/main/java/com/example/docconneting/domain/payment/service/PaymentApplicationService.java
@@ -3,7 +3,7 @@ package com.example.docconneting.domain.payment.service;
 import com.example.docconneting.common.config.annotation.DistributedLock;
 import com.example.docconneting.common.exception.constant.ErrorCode;
 import com.example.docconneting.common.exception.object.ClientException;
-import com.example.docconneting.domain.alarm.service.AlarmSenderService;
+import com.example.docconneting.domain.alarm.service.AlarmService;
 import com.example.docconneting.domain.auth.entity.AuthUser;
 import com.example.docconneting.domain.chatting.dto.response.ChattingRoomCreateResponse;
 import com.example.docconneting.domain.chatting.service.ChattingRoomService;
@@ -39,7 +39,7 @@ public class PaymentApplicationService {
     private final PortOneService portOneService;
     private final OrderService orderService;
     private final ChattingRoomService chattingRoomService;
-    private final AlarmSenderService alarmSenderService;
+    private final AlarmService alarmService;
     private final OrderRepository orderRepository;
     private final UserRepository userRepository;
     private final ChattingRoomAsyncService chattingRoomAsyncService;
@@ -96,7 +96,7 @@ public class PaymentApplicationService {
                 // 채팅 생성이 완료되면 의사에게 알람 전송
                 User patient = userRepository.findById(authUser.getId()).orElseThrow(() -> new ClientException(ErrorCode.USER_NOT_FOUND));
                 User doctor = userRepository.findById(order.getDoctorId()).orElseThrow(() -> new ClientException(ErrorCode.DOCTOR_NOT_FOUND));
-                alarmSenderService.sendMedicalRequestMessage(patient, doctor);
+                alarmService.sendMedicalRequestMessage(patient, doctor);
                 log.info("채팅 주문으로 채팅방 비동기 생성 시도 | doctorId={}", order.getDoctorId());
                 chattingRoomAsyncService.createChattingRoom(order);
             }

--- a/src/main/java/com/example/docconneting/domain/post/service/PostService.java
+++ b/src/main/java/com/example/docconneting/domain/post/service/PostService.java
@@ -5,7 +5,7 @@ import com.example.docconneting.common.exception.constant.ErrorCode;
 import com.example.docconneting.common.exception.object.ClientException;
 import com.example.docconneting.common.response.PageInfo;
 import com.example.docconneting.common.response.PageResult;
-import com.example.docconneting.domain.alarm.service.AlarmSenderService;
+import com.example.docconneting.domain.alarm.service.AlarmService;
 import com.example.docconneting.domain.auth.entity.AuthUser;
 import com.example.docconneting.domain.coupon.entity.PatientCoupon;
 import com.example.docconneting.domain.coupon.service.PatientCouponService;
@@ -38,7 +38,7 @@ public class PostService {
 
     private final PointService pointService;
     private final PatientCouponService patientCouponService;
-    private final AlarmSenderService alarmSenderService;
+    private final AlarmService alarmService;
     private final UserRepository userRepository;
     private final PostRepository postRepository;
     private final EntityManager entityManager;
@@ -73,7 +73,7 @@ public class PostService {
                 patientCouponService.useCoupon(user, couponId, savedPost.getId());
 
                 // 유료 게시물 등록 완료 후, 의사들에게 알람 전송
-                alarmSenderService.sendPostUploadCompletedMessage(major);
+                alarmService.sendPostUploadCompletedMessage(major);
             }
 
             case POINT -> {
@@ -83,7 +83,7 @@ public class PostService {
                 pointService.usePoint(user.getId(), savedPost.getId());
 
                 // 유료 게시물 등록 완료 후, 의사들에게 알람 전송
-                alarmSenderService.sendPostUploadCompletedMessage(major);
+                alarmService.sendPostUploadCompletedMessage(major);
                 pointService.usePoint(user.getId(), savedPost.getId());
             }
 

--- a/src/main/java/com/example/docconneting/domain/user/entity/User.java
+++ b/src/main/java/com/example/docconneting/domain/user/entity/User.java
@@ -107,6 +107,11 @@ public class User extends BaseEntity {
         this.fcmToken = fcmToken;
     }
 
+    // fcm 토큰을 제거하는 메서드
+    public void deleteFcmToken() {
+        this.fcmToken = null;
+    }
+
     // 알람 권한을 업데이트하는 메서드
     public void updateAlarmInfo(String fcmToken, Boolean isAlarmEnabled) {
         this.fcmToken = fcmToken;

--- a/src/main/java/com/example/docconneting/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/docconneting/domain/user/repository/UserRepository.java
@@ -17,6 +17,10 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
             "AND u.isDeleted = FALSE ")
     Optional<User> findByDoctorId(Long id);
 
+    @Query("SELECT u FROM User u " +
+            "WHERE u.fcmToken = :id ")
+    Optional<User> findByFcmToken(String fcmToken);
+
     Optional<User> findUserByIdAndUserRole(Long id, UserRole userRole);
 
     Optional<User> findByEmail(String email);

--- a/src/test/java/com/example/docconneting/domain/alarm/controller/AlarmControllerTest.java
+++ b/src/test/java/com/example/docconneting/domain/alarm/controller/AlarmControllerTest.java
@@ -1,0 +1,130 @@
+package com.example.docconneting.domain.alarm.controller;
+
+import com.example.docconneting.common.config.JwtUtil;
+import com.example.docconneting.common.filter.JwtFilter;
+import com.example.docconneting.common.resolver.AuthUserArgumentResolver;
+import com.example.docconneting.common.response.PageInfo;
+import com.example.docconneting.common.response.PageResult;
+import com.example.docconneting.domain.alarm.dto.AlarmResponse;
+import com.example.docconneting.domain.alarm.entity.AlarmHistories;
+import com.example.docconneting.domain.alarm.enums.AlarmType;
+import com.example.docconneting.domain.alarm.service.AlarmService;
+import com.example.docconneting.domain.auth.entity.AuthUser;
+import com.example.docconneting.domain.user.enums.UserRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.refEq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+@WebMvcTest(AlarmController.class)
+@TestPropertySource(properties = {
+        "jwt.secret.key=5Gk6hibHDtKLFVk4NdBX039rvehSLNjfKsdXpm/pHsU="
+})
+@Import({JwtUtil.class, AuthUserArgumentResolver.class, JwtFilter.class})
+class AlarmControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @MockitoBean
+    AlarmService alarmService;
+
+    @Autowired
+    JwtUtil jwtUtil;
+
+    AlarmHistories histories1;
+    AlarmHistories histories2;
+
+    @BeforeEach
+    void setUp() {
+        histories1 = AlarmHistories.of(
+                "회원님의 글에 댓글이 달렸습니다",
+                1L,
+                AlarmType.COMMENT
+        );
+        ReflectionTestUtils.setField(histories1, "id", 1L);
+        ReflectionTestUtils.setField(histories1, "createdAt", LocalDateTime.now());
+
+        histories2 = AlarmHistories.of(
+                "회원님의 글에 댓글이 달렸습니다",
+                1L,
+                AlarmType.COMMENT
+        );
+        ReflectionTestUtils.setField(histories2, "id", 2L);
+        ReflectionTestUtils.setField(histories2, "createdAt", LocalDateTime.now());
+    }
+
+    @Test
+    public void 알람_내역을_페이징을_이용하여_조회한다() throws Exception {
+        // given
+        int page = 0;
+        int size = 10;
+        int totalElement = 2;
+        int totalPages = 1;
+
+        Pageable pageable = PageRequest.of(page,size);
+
+        Long userId = 1L;
+        UserRole userRole = UserRole.PATIENT;
+        AuthUser authUser = AuthUser.of(userId, userRole);
+
+        String accessToken = jwtUtil.createToken(userId, userRole);
+
+        List<AlarmHistories> alarmHistories = new ArrayList<>();
+        alarmHistories.add(histories1);
+        alarmHistories.add(histories2);
+        List<AlarmResponse> alarmResponses = AlarmResponse.toAlarmResponse(alarmHistories);
+
+        PageInfo pageInfo = PageInfo.builder()
+                .pageNum(page)
+                .pageSize(size)
+                .totalElement(totalElement)
+                .totalPage(totalPages)
+                .build();
+
+        PageResult<AlarmResponse> pageResult = new PageResult<>(alarmResponses, pageInfo);
+
+        given(alarmService.findAlarms(refEq(authUser)
+                , argThat(p -> p.getPageNumber() == pageable.getPageNumber() && p.getPageSize() == pageable.getPageSize())))
+                .willReturn(pageResult);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/notifications")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .header("Authorization", accessToken))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].id").value(histories1.getId()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].content").value(histories1.getContent()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].alarmType").value(histories1.getAlarmType().name()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].id").value(histories2.getId()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].content").value(histories2.getContent()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].alarmType").value(histories2.getAlarmType().name()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.page.pageNum").value(page))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.page.pageSize").value(size))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalElement").value(totalElement))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalPage").value(totalPages));
+    }
+
+}

--- a/src/test/java/com/example/docconneting/domain/alarm/service/AlarmServiceTest.java
+++ b/src/test/java/com/example/docconneting/domain/alarm/service/AlarmServiceTest.java
@@ -1,0 +1,85 @@
+package com.example.docconneting.domain.alarm.service;
+
+import com.example.docconneting.common.response.PageResult;
+import com.example.docconneting.domain.alarm.dto.AlarmResponse;
+import com.example.docconneting.domain.alarm.entity.AlarmHistories;
+import com.example.docconneting.domain.alarm.enums.AlarmType;
+import com.example.docconneting.domain.alarm.repository.AlarmHistoriesRepository;
+import com.example.docconneting.domain.auth.entity.AuthUser;
+import com.example.docconneting.domain.user.enums.UserRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class AlarmServiceTest {
+
+    @Mock
+    private AlarmHistoriesRepository alarmHistoriesRepository;
+
+    @InjectMocks
+    private AlarmService alarmService;
+
+    private AlarmHistories histories1;
+    private AlarmHistories histories2;
+
+    @BeforeEach
+    void setUp() {
+        histories1 = AlarmHistories.of(
+                "회원님의 글에 댓글이 달렸습니다",
+                1L,
+                AlarmType.COMMENT
+        );
+        ReflectionTestUtils.setField(histories1, "id", 1L);
+
+        histories2 = AlarmHistories.of(
+                "회원님의 글에 댓글이 달렸습니다",
+                1L,
+                AlarmType.COMMENT
+        );
+        ReflectionTestUtils.setField(histories2, "id", 2L);
+    }
+
+    @Test
+    public void 알람_목록을_페이징을_적용하여_조회할_수_있다() {
+        // given
+        Long userId = 1L;
+        UserRole userRole = UserRole.PATIENT;
+        AuthUser authUser = AuthUser.of(userId, userRole);
+        int page = 0;
+        int size = 10;
+
+        Pageable pageable = PageRequest.of(page, size);
+        List<AlarmHistories> alarmHistories = new ArrayList<>();
+        alarmHistories.add(histories1);
+        alarmHistories.add(histories2);
+        Page<AlarmHistories> alarmPage = new PageImpl<>(alarmHistories, pageable, alarmHistories.size());
+
+        given(alarmHistoriesRepository.findAlarmHistories(userId, pageable)).willReturn(alarmPage);
+
+        // when
+        PageResult<AlarmResponse> result = alarmService.findAlarms(authUser, pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(alarmHistories.size());
+        assertThat(result.getPageInfo().getPageNum()).isEqualTo(page);
+        assertThat(result.getPageInfo().getPageSize()).isEqualTo(size);
+        assertThat(result.getPageInfo().getTotalElement()).isEqualTo(alarmHistories.size());
+        assertThat(result.getPageInfo().getTotalPage()).isEqualTo(1);
+    }
+
+}

--- a/src/test/java/com/example/docconneting/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/example/docconneting/domain/auth/controller/AuthControllerTest.java
@@ -4,7 +4,7 @@ package com.example.docconneting.domain.auth.controller;
 import com.example.docconneting.common.config.JwtUtil;
 import com.example.docconneting.common.filter.JwtFilter;
 import com.example.docconneting.common.resolver.AuthUserArgumentResolver;
-import com.example.docconneting.domain.alarm.service.AlarmSenderService;
+import com.example.docconneting.domain.alarm.service.AlarmService;
 import com.example.docconneting.domain.auth.dto.request.UserRefreshTokenRequest;
 import com.example.docconneting.domain.auth.dto.request.UserSignInRequest;
 import com.example.docconneting.domain.auth.dto.request.UserSignUpRequest;
@@ -36,7 +36,8 @@ import java.util.Map;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ActiveProfiles("test")
@@ -60,7 +61,7 @@ public class AuthControllerTest {
     private AuthService authService;
 
     @MockitoBean
-    private AlarmSenderService alarmSenderService;
+    private AlarmService alarmService;
 
     @MockitoBean
     private UserRepository userRepository;

--- a/src/test/java/com/example/docconneting/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/example/docconneting/domain/comment/service/CommentServiceTest.java
@@ -2,14 +2,14 @@ package com.example.docconneting.domain.comment.service;
 
 import com.example.docconneting.common.enums.Major;
 import com.example.docconneting.common.exception.constant.ErrorCode;
-import com.example.docconneting.common.exception.object.ServerException;
-import com.example.docconneting.domain.alarm.service.AlarmSenderService;
-import com.example.docconneting.domain.comment.dto.request.CommentRequest;
-import com.example.docconneting.domain.comment.dto.response.CommentResponse;
 import com.example.docconneting.common.exception.object.ClientException;
+import com.example.docconneting.common.exception.object.ServerException;
 import com.example.docconneting.common.response.PageInfo;
 import com.example.docconneting.common.response.PageResult;
+import com.example.docconneting.domain.alarm.service.AlarmService;
+import com.example.docconneting.domain.comment.dto.request.CommentRequest;
 import com.example.docconneting.domain.comment.dto.response.CommentListResponse;
+import com.example.docconneting.domain.comment.dto.response.CommentResponse;
 import com.example.docconneting.domain.comment.entity.Comment;
 import com.example.docconneting.domain.comment.repository.CommentRepository;
 import com.example.docconneting.domain.post.entity.Post;
@@ -41,8 +41,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
-import static org.mockito.Mockito.when;
-
 @ActiveProfiles("test")
 @TestClassOrder(ClassOrderer.OrderAnnotation.class)
 @ExtendWith(MockitoExtension.class)
@@ -61,7 +59,7 @@ class CommentServiceTest {
     private EntityManager entityManager;
 
     @Mock
-    AlarmSenderService alarmSenderService;
+    AlarmService alarmService;
 
     @InjectMocks
     private CommentService commentService;

--- a/src/test/java/com/example/docconneting/domain/payment/service/VerifyAndCreateOrderDistributedLockTest.java
+++ b/src/test/java/com/example/docconneting/domain/payment/service/VerifyAndCreateOrderDistributedLockTest.java
@@ -3,7 +3,7 @@ package com.example.docconneting.domain.payment.service;
 import com.example.docconneting.common.config.TestAsyncConfig;
 import com.example.docconneting.common.exception.constant.ErrorCode;
 import com.example.docconneting.common.exception.object.ClientException;
-import com.example.docconneting.domain.alarm.service.AlarmSenderService;
+import com.example.docconneting.domain.alarm.service.AlarmService;
 import com.example.docconneting.domain.auth.entity.AuthUser;
 import com.example.docconneting.domain.order.dto.request.OrderRequest;
 import com.example.docconneting.domain.order.enums.OrderProduct;
@@ -47,7 +47,7 @@ public class VerifyAndCreateOrderDistributedLockTest {
     private PortOneService portOneService;
 
     @MockitoBean
-    private AlarmSenderService alarmSenderService;
+    private AlarmService alarmService;
 
     @Autowired
     private OrderRepository orderRepository;

--- a/src/test/java/com/example/docconneting/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/example/docconneting/domain/post/service/PostServiceTest.java
@@ -5,7 +5,7 @@ import com.example.docconneting.common.exception.constant.ErrorCode;
 import com.example.docconneting.common.exception.object.ClientException;
 import com.example.docconneting.common.response.PageInfo;
 import com.example.docconneting.common.response.PageResult;
-import com.example.docconneting.domain.alarm.service.AlarmSenderService;
+import com.example.docconneting.domain.alarm.service.AlarmService;
 import com.example.docconneting.domain.auth.entity.AuthUser;
 import com.example.docconneting.domain.coupon.service.PatientCouponService;
 import com.example.docconneting.domain.point.service.PointService;
@@ -65,7 +65,7 @@ class PostServiceTest {
     PointService pointService;
 
     @Mock
-    AlarmSenderService alarmSenderService;
+    AlarmService alarmService;
 
     @InjectMocks
     PostService postService;


### PR DESCRIPTION
(#99)
- 단건 알람 전송 실패시 재시도 로직 추가 (@Retryable, @Recover 사용)
- 다건 알람 전송 실패시 재시도 로직 추가 (실패한 토큰 리스트만 모아서 반복문으로 재시도)
- INTERNAL, UNAVAILABLE 에러는 3회까지 지수 백오프를 사용하여 재시도
- INVALID_ARGUMENT, UNREGISTERED 에러는 토큰 삭제